### PR TITLE
add ErrClosed error type for natiu-mqtt

### DIFF
--- a/net.go
+++ b/net.go
@@ -197,3 +197,27 @@ func (e *AddrError) Error() string {
 	}
 	return s
 }
+
+// errNetClosing is the type of the variable ErrNetClosing.
+// This is used to implement the net.Error interface.
+type errNetClosing struct{}
+
+// Error returns the error message for ErrNetClosing.
+// Keep this string consistent because of issue #4373:
+// since historically programs have not been able to detect
+// this error, they look for the string.
+func (e errNetClosing) Error() string { return "use of closed network connection" }
+
+func (e errNetClosing) Timeout() bool   { return false }
+func (e errNetClosing) Temporary() bool { return false }
+
+// errClosed exists just so that the docs for ErrClosed don't mention
+// the internal package poll.
+var errClosed = errNetClosing{}
+
+// ErrClosed is the error returned by an I/O call on a network
+// connection that has already been closed, or that is closed by
+// another goroutine before the I/O is completed. This may be wrapped
+// in another error, and should normally be tested using
+// errors.Is(err, net.ErrClosed).
+var ErrClosed error = errClosed

--- a/netdev.go
+++ b/netdev.go
@@ -49,6 +49,10 @@ type netdever interface {
 	// address in standard dot notation
 	GetHostByName(name string) (IP, error)
 
+	// GetIPAddr returns IP address assigned to the interface, either by
+	// DHCP or statically
+	GetIPAddr() (IP, error)
+
 	// Berkely Sockets-like interface, Go-ified.  See man page for socket(2), etc.
 	Socket(domain int, stype int, protocol int) (int, error)
 	Bind(sockfd int, ip IP, port int) error

--- a/netdev.go
+++ b/netdev.go
@@ -1,3 +1,5 @@
+// L3/L4 network/transport layer
+
 package net
 
 import (
@@ -28,20 +30,19 @@ func useNetdev(dev netdever) {
 	netdev = dev
 }
 
-// Netdev is TinyGo's network device driver model.  Network drivers implement
-// the netdever interface, providing a common network I/O interface to TinyGo's
-// "net" package.  The interface is modeled after the BSD socket interface.
-// net.Conn implementations (TCPConn, UDPConn, and TLSConn) use the netdev
-// interface for device I/O access.
+// netdever is TinyGo's OSI L3/L4 network/transport layer interface.  Network
+// drivers implement the netdever interface, providing a common network L3/L4
+// interface to TinyGo's "net" package.  net.Conn implementations (TCPConn,
+// UDPConn, and TLSConn) use the netdever interface for device I/O access.
 //
 // A netdever is passed to the "net" package using net.useNetdev().
 //
 // Just like a net.Conn, multiple goroutines may invoke methods on a netdever
 // simultaneously.
 //
-// NOTE: The netdever interface is mirrored in drivers/netdev.go.
+// NOTE: The netdever interface is mirrored in drivers/netdev/netdev.go.
 // NOTE: If making changes to this interface, mirror the changes in
-// NOTE: drivers/netdev.go, and vice-versa.
+// NOTE: drivers/netdev/netdev.go, and vice-versa.
 
 type netdever interface {
 


### PR DESCRIPTION
natiu-mqtt needs ErrClosed error type to compile, so add it.