### PR TITLE
fix 'panic: runtime error: slice smaller than array' bug

### DIFF
--- a/tcpsock.go
+++ b/tcpsock.go
@@ -161,7 +161,8 @@ func DialTCP(network string, laddr, raddr *TCPAddr) (*TCPConn, error) {
 		return nil, err
 	}
 
-	raddrport := netip.AddrPortFrom(netip.AddrFrom4([4]byte(raddr.IP)), uint16(raddr.Port))
+	rip, _ := netip.AddrFromSlice(raddr.IP)
+	raddrport := netip.AddrPortFrom(rip, uint16(raddr.Port))
 	if err = netdev.Connect(fd, "", raddrport); err != nil {
 		netdev.Close(fd)
 		return nil, err
@@ -274,7 +275,8 @@ func listenTCP(laddr *TCPAddr) (Listener, error) {
 		return nil, err
 	}
 
-	laddrport := netip.AddrPortFrom(netip.AddrFrom4([4]byte(laddr.IP)), uint16(laddr.Port))
+	lip, _ := netip.AddrFromSlice(laddr.IP)
+	laddrport := netip.AddrPortFrom(lip, uint16(laddr.Port))
 	err = netdev.Bind(fd, laddrport)
 	if err != nil {
 		return nil, err

--- a/udpsock.go
+++ b/udpsock.go
@@ -172,7 +172,8 @@ func DialUDP(network string, laddr, raddr *UDPAddr) (*UDPConn, error) {
 	if err != nil {
 		return nil, err
 	}
-	laddrport := netip.AddrPortFrom(netip.AddrFrom4([4]byte(laddr.IP)), uint16(laddr.Port))
+	lip, _ := netip.AddrFromSlice(laddr.IP)
+	laddrport := netip.AddrPortFrom(lip, uint16(laddr.Port))
 
 	// Local bind
 	err = netdev.Bind(fd, laddrport)
@@ -181,7 +182,8 @@ func DialUDP(network string, laddr, raddr *UDPAddr) (*UDPConn, error) {
 		return nil, err
 	}
 
-	raddrport := netip.AddrPortFrom(netip.AddrFrom4([4]byte(raddr.IP)), uint16(raddr.Port))
+	rip, _ := netip.AddrFromSlice(raddr.IP)
+	raddrport := netip.AddrPortFrom(rip, uint16(raddr.Port))
 	// Remote connect
 	if err = netdev.Connect(fd, "", raddrport); err != nil {
 		netdev.Close(fd)


### PR DESCRIPTION
Fixes https://github.com/tinygo-org/net/issues/9.

netip.AddrFromSlice() will take a net.IP as an argument, so no need to cast IP as [4]byte.  The panic was caused by IP being set to IP{}, so the cast to [4]byte fails with:

panic: runtime error at 0x1000aa1f: slice smaller than array