### PR TITLE
stub out more types/funcs to compile against golang.org/x/net/internal/socket

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,11 @@ src/net
 │   ├── status.go
 │   ├── transfer.go		*
 │   └── transport.go		*
+├── interface.go		*
 ├── ip.go
 ├── iprawsock.go		*
 ├── ipsock.go			*
+├── lookup.go			*
 ├── mac.go
 ├── mac_test.go
 ├── netdev.go			+
@@ -61,10 +63,12 @@ src/net
 ├── README.md
 ├── tcpsock.go			*
 ├── tlssock.go			+
-└── udpsock.go			*
+├── udpsock.go			*
+└── unixsock.go			*
 
 src/crypto/tls/
 ├── common.go			*
+├── ticket.go			*
 └── tls.go			*
 ```
 

--- a/dial.go
+++ b/dial.go
@@ -14,8 +14,10 @@ package net
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
+	"syscall"
 )
 
 const (
@@ -23,6 +25,9 @@ const (
 	// See go.dev/issue/31510
 	defaultTCPKeepAlive = 15 * time.Second
 )
+
+// mptcpStatus is a tristate for Multipath TCP, see go.dev/issue/56539
+type mptcpStatus uint8
 
 // A Dialer contains options for connecting to an address.
 //
@@ -144,6 +149,46 @@ func (d *Dialer) DialContext(ctx context.Context, network, address string) (Conn
 	}
 
 	return nil, fmt.Errorf("Network %s not supported", network)
+}
+
+// ListenConfig contains options for listening to an address.
+type ListenConfig struct {
+	// If Control is not nil, it is called after creating the network
+	// connection but before binding it to the operating system.
+	//
+	// Network and address parameters passed to Control method are not
+	// necessarily the ones passed to Listen. For example, passing "tcp" to
+	// Listen will cause the Control function to be called with "tcp4" or "tcp6".
+	Control func(network, address string, c syscall.RawConn) error
+
+	// KeepAlive specifies the keep-alive period for network
+	// connections accepted by this listener.
+	// If zero, keep-alives are enabled if supported by the protocol
+	// and operating system. Network protocols or operating systems
+	// that do not support keep-alives ignore this field.
+	// If negative, keep-alives are disabled.
+	KeepAlive time.Duration
+
+	// If mptcpStatus is set to a value allowing Multipath TCP (MPTCP) to be
+	// used, any call to Listen with "tcp(4|6)" as network will use MPTCP if
+	// supported by the operating system.
+	mptcpStatus mptcpStatus
+}
+
+// Listen announces on the local network address.
+//
+// See func Listen for a description of the network and address
+// parameters.
+func (lc *ListenConfig) Listen(ctx context.Context, network, address string) (Listener, error) {
+	return nil, errors.New("dial:ListenConfig:Listen not implemented")
+}
+
+// ListenPacket announces on the local network address.
+//
+// See func ListenPacket for a description of the network and address
+// parameters.
+func (lc *ListenConfig) ListenPacket(ctx context.Context, network, address string) (PacketConn, error) {
+	return nil, errors.New("dial:ListenConfig:ListenPacket not implemented")
 }
 
 // Listen announces on the local network address.

--- a/interface.go
+++ b/interface.go
@@ -1,0 +1,86 @@
+// TINYGO: The following is copied and modified from Go 1.21.4 official implementation.
+
+// Copyright 2011 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package net
+
+import (
+	"errors"
+)
+
+// BUG(mikio): On JS, methods and functions related to
+// Interface are not implemented.
+
+// BUG(mikio): On AIX, DragonFly BSD, NetBSD, OpenBSD, Plan 9 and
+// Solaris, the MulticastAddrs method of Interface is not implemented.
+
+var (
+	errInvalidInterface         = errors.New("invalid network interface")
+	errInvalidInterfaceIndex    = errors.New("invalid network interface index")
+	errInvalidInterfaceName     = errors.New("invalid network interface name")
+	errNoSuchInterface          = errors.New("no such network interface")
+	errNoSuchMulticastInterface = errors.New("no such multicast network interface")
+)
+
+// Interface represents a mapping between network interface name
+// and index. It also represents network interface facility
+// information.
+type Interface struct {
+	Index        int          // positive integer that starts at one, zero is never used
+	MTU          int          // maximum transmission unit
+	Name         string       // e.g., "en0", "lo0", "eth0.100"
+	HardwareAddr HardwareAddr // IEEE MAC-48, EUI-48 and EUI-64 form
+	Flags        Flags        // e.g., FlagUp, FlagLoopback, FlagMulticast
+}
+
+type Flags uint
+
+const (
+	FlagUp           Flags = 1 << iota // interface is administratively up
+	FlagBroadcast                      // interface supports broadcast access capability
+	FlagLoopback                       // interface is a loopback interface
+	FlagPointToPoint                   // interface belongs to a point-to-point link
+	FlagMulticast                      // interface supports multicast access capability
+	FlagRunning                        // interface is in running state
+)
+
+var flagNames = []string{
+	"up",
+	"broadcast",
+	"loopback",
+	"pointtopoint",
+	"multicast",
+	"running",
+}
+
+func (f Flags) String() string {
+	s := ""
+	for i, name := range flagNames {
+		if f&(1<<uint(i)) != 0 {
+			if s != "" {
+				s += "|"
+			}
+			s += name
+		}
+	}
+	if s == "" {
+		s = "0"
+	}
+	return s
+}
+
+// Interfaces returns a list of the system's network interfaces.
+func Interfaces() ([]Interface, error) {
+	return nil, errors.New("Interfaces not implemented")
+}
+
+// InterfaceByIndex returns the interface specified by index.
+//
+// On Solaris, it returns one of the logical network interfaces
+// sharing the logical data link; for more precision use
+// InterfaceByName.
+func InterfaceByIndex(index int) (*Interface, error) {
+	return nil, errors.New("InterfaceByIndex not implemented")
+}

--- a/iprawsock.go
+++ b/iprawsock.go
@@ -6,6 +6,11 @@
 
 package net
 
+import (
+	"errors"
+	"syscall"
+)
+
 // BUG(mikio): On every POSIX platform, reads from the "ip4" network
 // using the ReadFrom or ReadFromIP method might not return a complete
 // IPv4 packet, including its header, even if there is space
@@ -56,4 +61,43 @@ func (a *IPAddr) opAddr() Addr {
 		return nil
 	}
 	return a
+}
+
+// IPConn is the implementation of the Conn and PacketConn interfaces
+// for IP network connections.
+type IPConn struct {
+	conn
+}
+
+// SyscallConn returns a raw network connection.
+// This implements the syscall.Conn interface.
+func (c *IPConn) SyscallConn() (syscall.RawConn, error) {
+	return nil, errors.New("SyscallConn not implemented")
+}
+
+// ReadMsgIP reads a message from c, copying the payload into b and
+// the associated out-of-band data into oob. It returns the number of
+// bytes copied into b, the number of bytes copied into oob, the flags
+// that were set on the message and the source address of the message.
+//
+// The packages golang.org/x/net/ipv4 and golang.org/x/net/ipv6 can be
+// used to manipulate IP-level socket options in oob.
+func (c *IPConn) ReadMsgIP(b, oob []byte) (n, oobn, flags int, addr *IPAddr, err error) {
+	err = errors.New("ReadMsgIP not implemented")
+	return
+}
+
+// ReadFrom implements the PacketConn ReadFrom method.
+func (c *IPConn) ReadFrom(b []byte) (int, Addr, error) {
+	return 0, nil, errors.New("ReadFrom not implemented")
+}
+
+// WriteToIP acts like WriteTo but takes an IPAddr.
+func (c *IPConn) WriteToIP(b []byte, addr *IPAddr) (int, error) {
+	return 0, errors.New("WriteToIP not implemented")
+}
+
+// WriteTo implements the PacketConn WriteTo method.
+func (c *IPConn) WriteTo(b []byte, addr Addr) (int, error) {
+	return 0, errors.New("WriteTo not implemented")
 }

--- a/lookup.go
+++ b/lookup.go
@@ -1,0 +1,19 @@
+// TINYGO: The following is copied and modified from Go 1.21.4 official implementation.
+
+// Copyright 2012 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package net
+
+import (
+	"errors"
+)
+
+// LookupPort looks up the port for the given network and service.
+//
+// LookupPort uses context.Background internally; to specify the context, use
+// Resolver.LookupPort.
+func LookupPort(network, service string) (port int, err error) {
+	return 0, errors.New("net:LookupPort not implemented")
+}

--- a/net.go
+++ b/net.go
@@ -7,6 +7,7 @@
 package net
 
 import (
+	"errors"
 	"time"
 )
 
@@ -77,6 +78,102 @@ type Conn interface {
 	// Even if write times out, it may return n > 0, indicating that
 	// some of the data was successfully written.
 	// A zero value for t means Write will not time out.
+	SetWriteDeadline(t time.Time) error
+}
+
+type conn struct {
+	// TINYGO: no fd defined
+}
+
+// Close closes the connection.
+func (c *conn) Close() error {
+	return errors.New("conn.Close not implemented")
+}
+
+// LocalAddr returns the local network address.
+// The Addr returned is shared by all invocations of LocalAddr, so
+// do not modify it.
+func (c *conn) LocalAddr() Addr {
+	// TINYGO: not implemented
+	return nil
+}
+
+// SetDeadline implements the Conn SetDeadline method.
+func (c *conn) SetDeadline(t time.Time) error {
+	return errors.New("conn.SetDeadline not implemented")
+}
+
+// SetReadDeadline implements the Conn SetReadDeadline method.
+func (c *conn) SetReadDeadline(t time.Time) error {
+	return errors.New("conn.SetReadDeadline not implemented")
+}
+
+// SetWriteDeadline implements the Conn SetWriteDeadline method.
+func (c *conn) SetWriteDeadline(t time.Time) error {
+	return errors.New("conn.SetWriteDeadline not implemented")
+}
+
+// PacketConn is a generic packet-oriented network connection.
+//
+// Multiple goroutines may invoke methods on a PacketConn simultaneously.
+type PacketConn interface {
+	// ReadFrom reads a packet from the connection,
+	// copying the payload into p. It returns the number of
+	// bytes copied into p and the return address that
+	// was on the packet.
+	// It returns the number of bytes read (0 <= n <= len(p))
+	// and any error encountered. Callers should always process
+	// the n > 0 bytes returned before considering the error err.
+	// ReadFrom can be made to time out and return an error after a
+	// fixed time limit; see SetDeadline and SetReadDeadline.
+	ReadFrom(p []byte) (n int, addr Addr, err error)
+
+	// WriteTo writes a packet with payload p to addr.
+	// WriteTo can be made to time out and return an Error after a
+	// fixed time limit; see SetDeadline and SetWriteDeadline.
+	// On packet-oriented connections, write timeouts are rare.
+	WriteTo(p []byte, addr Addr) (n int, err error)
+
+	// Close closes the connection.
+	// Any blocked ReadFrom or WriteTo operations will be unblocked and return errors.
+	Close() error
+
+	// LocalAddr returns the local network address, if known.
+	LocalAddr() Addr
+
+	// SetDeadline sets the read and write deadlines associated
+	// with the connection. It is equivalent to calling both
+	// SetReadDeadline and SetWriteDeadline.
+	//
+	// A deadline is an absolute time after which I/O operations
+	// fail instead of blocking. The deadline applies to all future
+	// and pending I/O, not just the immediately following call to
+	// Read or Write. After a deadline has been exceeded, the
+	// connection can be refreshed by setting a deadline in the future.
+	//
+	// If the deadline is exceeded a call to Read or Write or to other
+	// I/O methods will return an error that wraps os.ErrDeadlineExceeded.
+	// This can be tested using errors.Is(err, os.ErrDeadlineExceeded).
+	// The error's Timeout method will return true, but note that there
+	// are other possible errors for which the Timeout method will
+	// return true even if the deadline has not been exceeded.
+	//
+	// An idle timeout can be implemented by repeatedly extending
+	// the deadline after successful ReadFrom or WriteTo calls.
+	//
+	// A zero value for t means I/O operations will not time out.
+	SetDeadline(t time.Time) error
+
+	// SetReadDeadline sets the deadline for future ReadFrom calls
+	// and any currently-blocked ReadFrom call.
+	// A zero value for t means ReadFrom will not time out.
+	SetReadDeadline(t time.Time) error
+
+	// SetWriteDeadline sets the deadline for future WriteTo calls
+	// and any currently-blocked WriteTo call.
+	// Even if write times out, it may return n > 0, indicating that
+	// some of the data was successfully written.
+	// A zero value for t means WriteTo will not time out.
 	SetWriteDeadline(t time.Time) error
 }
 

--- a/netdev.go
+++ b/netdev.go
@@ -13,6 +13,7 @@ const (
 	_SOCK_DGRAM    = 0x2
 	_SOL_SOCKET    = 0x1
 	_SO_KEEPALIVE  = 0x9
+	_SO_LINGER     = 0xd
 	_SOL_TCP       = 0x6
 	_TCP_KEEPINTVL = 0x5
 	_IPPROTO_TCP   = 0x6

--- a/udpsock.go
+++ b/udpsock.go
@@ -7,11 +7,13 @@
 package net
 
 import (
+	"errors"
 	"fmt"
 	"internal/itoa"
 	"io"
 	"net/netip"
 	"strconv"
+	"syscall"
 	"time"
 )
 
@@ -198,6 +200,12 @@ func DialUDP(network string, laddr, raddr *UDPAddr) (*UDPConn, error) {
 	}, nil
 }
 
+// SyscallConn returns a raw network connection.
+// This implements the syscall.Conn interface.
+func (c *UDPConn) SyscallConn() (syscall.RawConn, error) {
+	return nil, errors.New("SyscallConn not implemented")
+}
+
 // TINYGO: Use netdev for Conn methods: Read = Recv, Write = Send, etc.
 
 func (c *UDPConn) Read(b []byte) (int, error) {
@@ -222,6 +230,40 @@ func (c *UDPConn) Write(b []byte) (int, error) {
 		err = &OpError{Op: "write", Net: c.net, Source: c.laddr, Addr: c.raddr, Err: err}
 	}
 	return n, err
+}
+
+// ReadFrom implements the PacketConn ReadFrom method.
+func (c *UDPConn) ReadFrom(b []byte) (int, Addr, error) {
+	return 0, nil, errors.New("ReadFrom not implemented")
+}
+
+// ReadMsgUDP reads a message from c, copying the payload into b and
+// the associated out-of-band data into oob. It returns the number of
+// bytes copied into b, the number of bytes copied into oob, the flags
+// that were set on the message and the source address of the message.
+//
+// The packages golang.org/x/net/ipv4 and golang.org/x/net/ipv6 can be
+// used to manipulate IP-level socket options in oob.
+func (c *UDPConn) ReadMsgUDP(b, oob []byte) (n, oobn, flags int, addr *UDPAddr, err error) {
+	err = errors.New("ReadMsgUDP not implemented")
+	return
+}
+
+// WriteTo implements the PacketConn WriteTo method.
+func (c *UDPConn) WriteTo(b []byte, addr Addr) (int, error) {
+	return 0, errors.New("WriteTo not implemented")
+}
+
+// WriteMsgUDP writes a message to addr via c if c isn't connected, or
+// to c's remote address if c is connected (in which case addr must be
+// nil). The payload is copied from b and the associated out-of-band
+// data is copied from oob. It returns the number of payload and
+// out-of-band bytes written.
+//
+// The packages golang.org/x/net/ipv4 and golang.org/x/net/ipv6 can be
+// used to manipulate IP-level socket options in oob.
+func (c *UDPConn) WriteMsgUDP(b, oob []byte, addr *UDPAddr) (n, oobn int, err error) {
+	return 0, 0, errors.New("WriteMsgUDP not implemented")
 }
 
 func (c *UDPConn) Close() error {

--- a/unixsock.go
+++ b/unixsock.go
@@ -1,0 +1,46 @@
+// TINYGO: The following is copied and modified from Go 1.21.4 official implementation.
+
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package net
+
+import (
+)
+
+// BUG(mikio): On JS, WASIP1 and Plan 9, methods and functions related
+// to UnixConn and UnixListener are not implemented.
+
+// BUG(mikio): On Windows, methods and functions related to UnixConn
+// and UnixListener don't work for "unixgram" and "unixpacket".
+
+// UnixAddr represents the address of a Unix domain socket end point.
+type UnixAddr struct {
+	Name string
+	Net  string
+}
+
+// Network returns the address's network name, "unix", "unixgram" or
+// "unixpacket".
+func (a *UnixAddr) Network() string {
+	return a.Net
+}
+
+func (a *UnixAddr) String() string {
+	if a == nil {
+		return "<nil>"
+	}
+	return a.Name
+}
+
+func (a *UnixAddr) isWildcard() bool {
+	return a == nil || a.Name == ""
+}
+
+func (a *UnixAddr) opAddr() Addr {
+	if a == nil {
+		return nil
+	}
+	return a
+}


### PR DESCRIPTION
This is for tinygo-org/net/issues/14. Basically, trying to get apps which import golang.org/x/net/internal/socket to compile.

This PR covers the additions needed to src/net. There is a matching matching PR (tinygo-org/tinygo/pull/4035) in tinygo-org/tinygo for the "crypto/tls" package changes for tinygo-org/net/issues/14.