### PR TITLE
correct netdever Accept() prototype

### DIFF
--- a/netdev.go
+++ b/netdev.go
@@ -95,7 +95,7 @@ type netdever interface {
 	Bind(sockfd int, ip netip.AddrPort) error
 	Connect(sockfd int, host string, ip netip.AddrPort) error
 	Listen(sockfd int, backlog int) error
-	Accept(sockfd int, ip netip.AddrPort) (int, error)
+	Accept(sockfd int) (int, netip.AddrPort, error)
 
 	// # Flags argument on Send and Recv
 	//


### PR DESCRIPTION
According to man page accept(2), accept returns new client sockfd and remote peer ip:port.  This patch corrects the Accept() prototype in the netdever interface to not take in an ip:port arg, but rather return an ip:port for remote peer.

Tested with examples/net/tcpecho on wioterminal and nano-rp2040. Here's a run with wioterminal:

```
SERVER
============
sfeldma@nuc:~/work/drivers$ tinygo flash -monitor -target wioterminal -size short -stack-size=8kb ./examples/net/tcpecho
code data bss | flash ram
110876 2552 11212 | 113428 13764
Connected to /dev/ttyACM2. Press Ctrl-C to exit.

Realtek rtl8720dn Wifi network device driver (rtl8720dn)

Driver version : 0.0.1
RTL8720 firmware version : 2.1.2
MAC address : 2c:f7:f1:1c:9b:2f

Connecting to Wifi SSID 'test'...CONNECTED

DHCP-assigned IP : 10.0.0.140
DHCP-assigned subnet : 255.255.255.0
DHCP-assigned gateway : 10.0.0.1

Starting TCP server listening on :8080
Client 10.0.0.190:50000 connected
Client 10.0.0.190:50000 closed

CLIENT
=========
nc -p 50000 10.0.0.140 8080
```