### PR TITLE
add bare minimum DefaultTransport

### DIFF
--- a/http/client.go
+++ b/http/client.go
@@ -410,6 +410,10 @@ func urlErrorOp(method string) string {
 // Any returned error will be of type *url.Error. The url.Error
 // value's Timeout method will report true if the request timed out.
 func (c *Client) Do(req *Request) (*Response, error) {
+	if c.Transport != nil {
+		return c.Transport.RoundTrip(req)
+	}
+
 	return c.do(req)
 }
 

--- a/http/transport.go
+++ b/http/transport.go
@@ -20,3 +20,12 @@ type readTrackingBody struct {
 	didRead  bool
 	didClose bool
 }
+
+type Transport struct{}
+
+var DefaultTransport RoundTripper = &Transport{}
+
+// roundTrip implements a RoundTripper over HTTP.
+func (t *Transport) RoundTrip(req *Request) (*Response, error) {
+	return roundTrip(req)
+}


### PR DESCRIPTION
This PR adds very basic DefaultTransport to net package for tinygo. This helps fix compilation issues when using packages that depend on this.

this pr also fixes #30 (if you insist that it should be a different PR, i am happy to submit it as a separate one)

many thanks for considering this
Rajat Jindal