### PR TITLE
fix: add missing UnknownNetworkError

### DIFF
--- a/net.go
+++ b/net.go
@@ -193,6 +193,12 @@ type Listener interface {
 	Addr() Addr
 }
 
+type UnknownNetworkError string
+
+func (e UnknownNetworkError) Error() string   { return "unknown network " + string(e) }
+func (e UnknownNetworkError) Timeout() bool   { return false }
+func (e UnknownNetworkError) Temporary() bool { return false }
+
 // An Error represents a network error.
 type Error interface {
 	error


### PR DESCRIPTION
The net package recently added support for a custom transport to be added, largely to support the changes in tinygo for wasip2. 

This PR adds the missing error type UnknownNetworkError that was introduced in #25 

After adding this and updating the submodule reference in tinygo for the net package - custom HTTP transports can be successfully called when targeting wasip2. 

Referenced in #31