### PR TITLE
net: implement ResolveIPAddr with stub for lookupProtocol, take #2

### DIFF
--- a/iprawsock.go
+++ b/iprawsock.go
@@ -63,6 +63,23 @@ func (a *IPAddr) opAddr() Addr {
 	return a
 }
 
+// ResolveIPAddr returns an address of IP end point.
+//
+// The network must be an IP network name.
+//
+// If the host in the address parameter is not a literal IP address,
+// ResolveIPAddr resolves the address to an address of IP end point.
+// Otherwise, it parses the address as a literal IP address.
+// The address parameter can use a host name, but this is not
+// recommended, because it will return at most one of the host name's
+// IP addresses.
+//
+// See func [Dial] for a description of the network and address
+// parameters.
+func ResolveIPAddr(network, address string) (*IPAddr, error) {
+	return nil, errors.New("ResolveIPAddr not implemented")
+}
+
 // IPConn is the implementation of the Conn and PacketConn interfaces
 // for IP network connections.
 type IPConn struct {

--- a/lookup_unix.go
+++ b/lookup_unix.go
@@ -1,0 +1,20 @@
+// TINYGO: The following is copied and modified from Go 1.22.0 official implementation.
+
+// Copyright 2011 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build unix || js || wasip1
+
+package net
+
+import (
+	"context"
+	"errors"
+)
+
+// lookupProtocol looks up IP protocol name in /etc/protocols and
+// returns correspondent protocol number.
+func lookupProtocol(_ context.Context, name string) (int, error) {
+	return 0, errors.New("net:lookupProtocol not implemented")
+}


### PR DESCRIPTION
Hi @paralin, I hope you don't mind me resurrecting PR#24.

This is a rework of PR#24 based on review comments.  The rework mostly involved moving changes to the proper files, aligning with upstream Go src/net file layout.

I tested this PR on examples/net examples.  No issues, but those tests don't hit the newly added changes, so not expecting any issues.  Code changes by inspection LGTM.

If this PR is merged, PR#24 can be closed.