### PR TITLE
add lookupProtocol for windows

### DIFF
--- a/lookup_windows.go
+++ b/lookup_windows.go
@@ -1,0 +1,17 @@
+// TINYGO: The following is copied and modified from Go 1.22.0 official implementation.
+
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package net
+
+import (
+	"context"
+	"errors"
+)
+
+// lookupProtocol looks up IP protocol name and returns correspondent protocol number.
+func lookupProtocol(ctx context.Context, name string) (int, error) {
+	return 0, errors.New("net:lookupProtocol not implemented")
+}


### PR DESCRIPTION
This fixes a problem with https://github.com/tinygo-org/net/pull/36 which causes the Windows TinyGO build to fail.  The problem is the function lookupProtocol was missing for Windows build.  This PR adds the function for Windows.

I can't really test this because I don't have a Windows system, but by inspection is seems like it's correct.