### PR TITLE
http: add CheckRedirect field to Client for compatibility with oauth2

### DIFF
--- a/http/client.go
+++ b/http/client.go
@@ -61,6 +61,22 @@ type Client struct {
 	// If nil, DefaultTransport is used.
 	Transport RoundTripper
 
+	// CheckRedirect specifies the policy for handling redirects.
+	// If CheckRedirect is not nil, the client calls it before
+	// following an HTTP redirect. The arguments req and via are
+	// the upcoming request and the requests made already, oldest
+	// first. If CheckRedirect returns an error, the Client's Get
+	// method returns both the previous Response (with its Body
+	// closed) and CheckRedirect's error (wrapped in a url.Error)
+	// instead of issuing the Request req.
+	// As a special case, if CheckRedirect returns ErrUseLastResponse,
+	// then the most recent response is returned with its body
+	// unclosed, along with a nil error.
+	//
+	// If CheckRedirect is nil, the Client uses its default policy,
+	// which is to stop after 10 consecutive requests.
+	CheckRedirect func(req *Request, via []*Request) error
+
 	// Jar specifies the cookie jar.
 	//
 	// The Jar is used to insert relevant cookies into every


### PR DESCRIPTION
This change introduces a CheckRedirect field to the http.Client struct in TinyGo,  mirroring the behavior of Go's standard library http.Client.

The purpose of this addition is to resolve build errors in projects that rely  on packages (such as [golang.org/x/oauth2](https://github.com/golang/oauth2)) expecting the Client to have a  [CheckRedirect field](https://github.com/golang/oauth2/blob/master/oauth2.go#L364).  The field provides no functional change within TinyGo’s  HTTP client at this time — it is only included for API compatibility and  compilation success. There is no effect on runtime behavior unless explicitly  used by downstream code.