### PR TITLE
net: use internal/itoa for Go < 1.26 to fix build with older Go versions

### DIFF
--- a/ip.go
+++ b/ip.go
@@ -14,7 +14,6 @@ package net
 
 import (
 	"internal/bytealg"
-	"internal/strconv"
 	"internal/stringslite"
 	"net/netip"
 )
@@ -515,7 +514,7 @@ func (n *IPNet) String() string {
 	if l == -1 {
 		return nn.String() + "/" + m.String()
 	}
-	return nn.String() + "/" + strconv.Itoa(l)
+	return nn.String() + "/" + netItoa(l)
 }
 
 // ParseIP parses s as an IP address, returning the result.

--- a/itoa_go126.go
+++ b/itoa_go126.go
@@ -1,0 +1,7 @@
+//go:build go1.26
+
+package net
+
+import "internal/strconv"
+
+func netItoa(i int) string { return strconv.Itoa(i) }

--- a/itoa_pre126.go
+++ b/itoa_pre126.go
@@ -1,0 +1,7 @@
+//go:build !go1.26
+
+package net
+
+import "internal/itoa"
+
+func netItoa(i int) string { return itoa.Itoa(i) }


### PR DESCRIPTION
internal/strconv was added in Go 1.26. For older Go versions, use internal/itoa (already present in TinyGo) via a build tag shim.

Fixes TinyGo https://github.com/tinygo-org/tinygo/issues/5332