### PR TITLE
http: fix t.roundTrip undefined on js/wasm builds

### DIFF
--- a/http/roundtrip_js.go
+++ b/http/roundtrip_js.go
@@ -68,9 +68,11 @@ func (t *Transport) RoundTrip(req *Request) (*Response, error) {
 	// to fall back on the Fetch API, unless it's not available.
 
 	// TINYGO: Dial/DialTLS & DialContext/DialTLSContext are not present in tinygo Transport struct, therefore the
-	// corresponding if statements were removed
+	// corresponding if statements were removed.
+	// TINYGO: t.roundTrip (the private fallback used by upstream Go) is not present in the TinyGo stub
+	// Transport, so return an error when the Fetch API is unavailable instead of calling it.
 	if jsFetchMissing || jsFetchDisabled {
-		return t.roundTrip(req)
+		return nil, errors.New("net/http: Fetch API is not available and no fallback transport is implemented for js/wasm")
 	}
 
 	ac := js.Global().Get("AbortController")


### PR DESCRIPTION
The js/wasm RoundTrip fallback called t.roundTrip(req), an upstream Go private method that was never backported to TinyGo's Transport stub.

Replace the call with an explicit error return, since the empty Transport has no dial capability and cannot perform a fallback round-trip.

Fixes #52