### PR TITLE
net/http: fix nil didTimeout deref when a client dial fails

### DIFF
--- a/http/client.go
+++ b/http/client.go
@@ -213,10 +213,14 @@ func send(req *Request, deadline time.Time) (resp *Response, didTimeout func() b
 
 		// TINYGO: Remove TLS error check
 
-		return nil, didTimeout, err
+		// didTimeout must be non-nil whenever err != nil: c.do calls
+		// didTimeout() on the error path. The named return is nil here (TinyGo
+		// dropped setRequestCancel), so return alwaysFalse instead to avoid a
+		// nil func-value dereference on a failed dial.
+		return nil, alwaysFalse, err
 	}
 	if resp == nil {
-		return nil, didTimeout, fmt.Errorf("http: sendit returned a nil *Response with a nil error")
+		return nil, alwaysFalse, fmt.Errorf("http: sendit returned a nil *Response with a nil error")
 	}
 
 	// TINYGO: Skip check for resp.Body == nil since we'll set it in roundTrip


### PR DESCRIPTION
A failed dial panics instead of returning the error.

`send()` returns the named `didTimeout` on its error paths, but TinyGo dropped `setRequestCancel`, so nothing ever assigns it — it is a nil `func() bool`. `Client.do` then calls it on exactly that path:

```go
if !deadline.IsZero() && didTimeout() {   // client.go:465
```

so any client request whose dial fails with a deadline set dereferences a nil func value. The error the user should have seen never surfaces.

`alwaysFalse` already exists in this file (line 386) for precisely this shape, so the fix is to return it rather than the never-assigned named return. Same on the "nil \*Response with a nil error" path just below, which had the same problem.

Found while running gRPC over TinyGo, where a refused connection paniced rather than reporting a dial error.