### PR TITLE
net/http: add Transport.TLSHandshakeTimeout for source compatibility

### DIFF
--- a/http/transport.go
+++ b/http/transport.go
@@ -61,6 +61,12 @@ type Transport struct {
 	// headers if the request has an "Expect: 100-continue" header.
 	ExpectContinueTimeout time.Duration
 
+	// TLSHandshakeTimeout specifies the maximum amount of time to
+	// wait for a TLS handshake. Zero means no timeout.
+	// Accepted for source compatibility with net/http; the TinyGo
+	// transport performs the handshake inline so this is advisory.
+	TLSHandshakeTimeout time.Duration
+
 	// MaxResponseHeaderBytes specifies a limit on how many response bytes are
 	// allowed in the server's response header. Zero means to use a default limit.
 	MaxResponseHeaderBytes int64


### PR DESCRIPTION
Code that configures `&http.Transport{TLSHandshakeTimeout: ...}` — common in library and service code copied from a std-Go project — fails to compile here for want of the field.

This adds it as a stored-only field, and the doc comment says exactly that: this transport performs the handshake inline, so the value is advisory rather than enforced. I'd rather it be honest about not being wired up than silently imply a timeout nobody applies.

Happy to drop it if you'd prefer the compile error over a field that doesn't do anything — that's a reasonable position and your call. The argument for having it is that it's the difference between a dependency building or not, for a knob whose absence is rarely load-bearing.