### PR TITLE
net/http: add ErrUseLastResponse, Client.CloseIdleConnections, Transport.Proxy and ProxyURL

### DIFF
--- a/http/client.go
+++ b/http/client.go
@@ -27,6 +27,11 @@ import (
 	"golang.org/x/net/http/httpguts"
 )
 
+// ErrUseLastResponse can be returned by Client.CheckRedirect to control how
+// redirects are processed: the most recent response is returned with its body
+// unclosed, and the error is nil. TINYGO: provided for API compatibility.
+var ErrUseLastResponse = errors.New("net/http: use last response")
+
 // A Client is an HTTP client. Its zero value ([DefaultClient]) is a
 // usable client that uses [DefaultTransport].
 //
@@ -584,4 +589,14 @@ func (c *Client) Head(url string) (resp *Response, err error) {
 		return nil, err
 	}
 	return c.Do(req)
+}
+
+// CloseIdleConnections closes any connections on its Transport which were
+// previously connected from previous requests but are now idle. It delegates to
+// the Transport's CloseIdleConnections if it has one.
+func (c *Client) CloseIdleConnections() {
+	type closeIdler interface{ CloseIdleConnections() }
+	if tr, ok := c.Transport.(closeIdler); ok {
+		tr.CloseIdleConnections()
+	}
 }

--- a/http/transport.go
+++ b/http/transport.go
@@ -34,6 +34,13 @@ type readTrackingBody struct {
 // golang.org/x/net/http2 and google.golang.org/grpc. They are stored but, aside
 // from fetch, have no effect at runtime.
 type Transport struct {
+	// Proxy specifies a function to return a proxy for a given Request.
+	//
+	// TINYGO: present for API compatibility (callers set it, e.g. skywire's
+	// forward-proxy); the netdev-backed transport dials directly and does not
+	// consult it.
+	Proxy func(*Request) (*url.URL, error)
+
 	// TLSClientConfig specifies the TLS configuration to use with tls.Client.
 	TLSClientConfig *tls.Config
 
@@ -128,6 +135,14 @@ func (t *Transport) Clone() *Transport {
 // connection.
 func ProxyFromEnvironment(req *Request) (*url.URL, error) {
 	return nil, nil
+}
+
+// ProxyURL returns a proxy function (for use in a Transport) that always returns
+// the same URL.
+func ProxyURL(fixedURL *url.URL) func(*Request) (*url.URL, error) {
+	return func(*Request) (*url.URL, error) {
+		return fixedURL, nil
+	}
 }
 
 // ErrSkipAltProtocol is a sentinel error value defined by Transport.RegisterProtocol.

--- a/http/transport.go
+++ b/http/transport.go
@@ -36,9 +36,8 @@ type readTrackingBody struct {
 type Transport struct {
 	// Proxy specifies a function to return a proxy for a given Request.
 	//
-	// TINYGO: present for API compatibility (callers set it, e.g. skywire's
-	// forward-proxy); the netdev-backed transport dials directly and does not
-	// consult it.
+	// TINYGO: present for API compatibility; the netdev-backed transport dials
+	// directly and does not consult it.
 	Proxy func(*Request) (*url.URL, error)
 
 	// TLSClientConfig specifies the TLS configuration to use with tls.Client.


### PR DESCRIPTION
Four API-compatibility fills in `net/http`. Programs that reference any of them currently fail to compile against this package even when the feature is irrelevant to how they run.

- `ErrUseLastResponse` — the sentinel a `CheckRedirect` func returns to stop following redirects. Nothing has to act on it beyond existing.
- `Client.CloseIdleConnections` — delegates to the Transport when it has the method, which is what upstream net/http does.
- `ProxyURL` — returns a proxy function that always yields the same URL.
- `Transport.Proxy` — the field itself.

**One caveat worth stating plainly:** `Transport.Proxy` is accepted but not consulted. The netdev-backed transport dials directly. A caller that sets it gets a client that compiles and runs but ignores the proxy, which is a real footgun — I have commented it as such at the field. If you would rather not carry a field that silently does nothing, I am happy to drop `Proxy`/`ProxyURL` and keep only the first two, which have no such caveat.

Independent of #59 — this touches no netdev code and applies to `main` directly.

Found while building Skycoin's skywire against TinyGo, where each of these was a compile error before it was anything else.