### PR TITLE
net/http: follow redirects in the client again

### DIFF
--- a/http/client.go
+++ b/http/client.go
@@ -21,6 +21,7 @@ import (
 	"net"
 	"net/http/internal/ascii"
 	"net/url"
+	"slices"
 	"strings"
 	"time"
 
@@ -28,8 +29,8 @@ import (
 )
 
 // ErrUseLastResponse can be returned by Client.CheckRedirect to control how
-// redirects are processed: the most recent response is returned with its body
-// unclosed, and the error is nil. TINYGO: provided for API compatibility.
+// redirects are processed. If returned, the next request is not sent and the
+// most recent response is returned with its body unclosed.
 var ErrUseLastResponse = errors.New("net/http: use last response")
 
 // A Client is an HTTP client. Its zero value ([DefaultClient]) is a
@@ -144,6 +145,35 @@ type RoundTripper interface {
 	//
 	// The Request's URL and Header fields must be initialized.
 	RoundTrip(*Request) (*Response, error)
+}
+
+// refererForURL returns a referer without any authentication info or
+// an empty string if lastReq scheme is https and newReq scheme is http.
+// If the referer was explicitly set, then it will continue to be used.
+func refererForURL(lastReq, newReq *url.URL, explicitRef string) string {
+	// https://tools.ietf.org/html/rfc7231#section-5.5.2
+	//   "Clients SHOULD NOT include a Referer header field in a
+	//    (non-secure) HTTP request if the referring page was
+	//    transferred with a secure protocol."
+	if lastReq.Scheme == "https" && newReq.Scheme == "http" {
+		return ""
+	}
+	if explicitRef != "" {
+		return explicitRef
+	}
+
+	referer := lastReq.String()
+	if lastReq.User != nil {
+		// This is not very efficient, but is the best we can
+		// do without:
+		// - introducing a new method on URL
+		// - creating a race condition
+		// - copying the URL struct manually, which would cause
+		//   maintenance problems down the line
+		auth := lastReq.User.String() + "@"
+		referer = strings.Replace(referer, auth, "", 1)
+	}
+	return referer
 }
 
 // didTimeout is non-nil only if err != nil.
@@ -280,7 +310,12 @@ func roundTrip(req *Request) (*Response, error) {
 	var conn net.Conn
 	var err error
 
+	// TINYGO: NewRequest fills Request.Host from the URL, but a redirect hop
+	// TINYGO: builds its request directly and leaves it empty, so use the URL.
 	host := req.Host
+	if host == "" {
+		host = req.URL.Host
+	}
 	missingPort := !strings.Contains(host, ":")
 
 	switch scheme {
@@ -390,6 +425,55 @@ func (c *Client) Get(url string) (resp *Response, err error) {
 
 func alwaysFalse() bool { return false }
 
+// checkRedirect calls either the user's configured CheckRedirect
+// function, or the default.
+func (c *Client) checkRedirect(req *Request, via []*Request) error {
+	fn := c.CheckRedirect
+	if fn == nil {
+		fn = defaultCheckRedirect
+	}
+	return fn(req, via)
+}
+
+func defaultCheckRedirect(req *Request, via []*Request) error {
+	if len(via) >= 10 {
+		return errors.New("stopped after 10 redirects")
+	}
+	return nil
+}
+
+// redirectBehavior describes what should happen when the
+// client encounters a 3xx status code from the server.
+func redirectBehavior(reqMethod string, resp *Response, ireq *Request) (redirectMethod string, shouldRedirect, includeBody bool) {
+	switch resp.StatusCode {
+	case 301, 302, 303:
+		redirectMethod = reqMethod
+		shouldRedirect = true
+		includeBody = false
+
+		// RFC 2616 allowed automatic redirection only with GET and
+		// HEAD requests. RFC 7231 lifts this restriction, but we still
+		// restrict other methods to GET to maintain compatibility.
+		// See Issue 18570.
+		if reqMethod != "GET" && reqMethod != "HEAD" {
+			redirectMethod = "GET"
+		}
+	case 307, 308:
+		redirectMethod = reqMethod
+		shouldRedirect = true
+		includeBody = true
+
+		if ireq.GetBody == nil && ireq.outgoingLength() != 0 {
+			// We had a request body, and 307/308 require
+			// re-sending it, but GetBody is not defined. So just
+			// return this response to the user instead of an
+			// error, like we did in Go 1.7 and earlier.
+			shouldRedirect = false
+		}
+	}
+	return redirectMethod, shouldRedirect, includeBody
+}
+
 // urlErrorOp returns the (*url.Error).Op value to use for the
 // provided (*Request).Method value.
 func urlErrorOp(method string) string {
@@ -440,6 +524,8 @@ func urlErrorOp(method string) string {
 // Any returned error will be of type [*url.Error]. The url.Error
 // value's Timeout method will report true if the request timed out.
 func (c *Client) Do(req *Request) (*Response, error) {
+	// TINYGO: c.send() does not read c.Transport, because this port has no
+	// TINYGO: Transport implementation.
 	if c.Transport != nil {
 		return c.Transport.RoundTrip(req)
 	}
@@ -457,23 +543,287 @@ func (c *Client) do(req *Request) (retres *Response, reterr error) {
 	}
 	_ = *c // panic early if c is nil; see go.dev/issue/53521
 
-	var err error
-	var didTimeout func() bool
-	var resp *Response
-	var deadline = c.deadline()
+	var (
+		deadline      = c.deadline()
+		reqs          []*Request
+		resp          *Response
+		copyHeaders   = c.makeHeadersCopier(req)
+		reqBodyClosed = false // have we closed the current req.Body?
 
-	// TINYGO: lots removed here, mostly handling multiple requests.
-	// TINYGO: we just want simple GET, POST, etc.  In and out.
-
-	if resp, didTimeout, err = c.send(req, deadline); err != nil {
-		// c.send() always closes req.Body
-		if !deadline.IsZero() && didTimeout() {
-			return nil, fmt.Errorf("%s (Client.Timeout exceeded while awaiting headers)", err.Error())
+		// Redirect behavior:
+		redirectMethod        string
+		includeBody           = true
+		stripSensitiveHeaders = false
+	)
+	uerr := func(err error) error {
+		// the body may have been closed already by c.send()
+		if !reqBodyClosed {
+			req.closeBody()
 		}
-		return nil, err
+		var urlStr string
+		if resp != nil && resp.Request != nil {
+			urlStr = stripPassword(resp.Request.URL)
+		} else {
+			urlStr = stripPassword(req.URL)
+		}
+		return &url.Error{
+			Op:  urlErrorOp(reqs[0].Method),
+			URL: urlStr,
+			Err: err,
+		}
+	}
+	for {
+		// For all but the first request, create the next
+		// request hop and replace req.
+		if len(reqs) > 0 {
+			loc := resp.Header.Get("Location")
+			if loc == "" {
+				// While most 3xx responses include a Location, it is not
+				// required and 3xx responses without a Location have been
+				// observed in the wild. See issues #17773 and #49281.
+				return resp, nil
+			}
+			u, err := req.URL.Parse(loc)
+			if err != nil {
+				resp.closeBody()
+				return nil, uerr(fmt.Errorf("failed to parse Location header %q: %v", loc, err))
+			}
+			host := ""
+			if req.Host != "" && req.Host != req.URL.Host {
+				// If the caller specified a custom Host header and the
+				// redirect location is relative, preserve the Host header
+				// through the redirect. See issue #22233.
+				if u, _ := url.Parse(loc); u != nil && !u.IsAbs() {
+					host = req.Host
+				}
+			}
+			ireq := reqs[0]
+			req = &Request{
+				Method:     redirectMethod,
+				Response:   resp,
+				URL:        u,
+				Header:     make(Header),
+				Host:       host,
+				Cancel:     ireq.Cancel,
+				ctx:        ireq.ctx,
+				Proto:      "HTTP/1.1",
+				ProtoMajor: 1,
+				ProtoMinor: 1,
+			}
+			if includeBody && ireq.GetBody != nil {
+				req.Body, err = ireq.GetBody()
+				if err != nil {
+					resp.closeBody()
+					return nil, uerr(err)
+				}
+				req.GetBody = ireq.GetBody
+				req.ContentLength = ireq.ContentLength
+			}
+
+			// Copy original headers before setting the Referer,
+			// in case the user set Referer on their first request.
+			// If they really want to override, they can do it in
+			// their CheckRedirect func.
+			if !stripSensitiveHeaders && reqs[0].URL.Host != req.URL.Host {
+				if !shouldCopyHeaderOnRedirect(reqs[0].URL, req.URL) {
+					stripSensitiveHeaders = true
+				}
+			}
+			copyHeaders(req, stripSensitiveHeaders, !includeBody)
+			// Add the Referer header from the most recent
+			// request URL to the new one, if it's not https->http:
+			if ref := refererForURL(reqs[len(reqs)-1].URL, req.URL, req.Header.Get("Referer")); ref != "" {
+				req.Header.Set("Referer", ref)
+			}
+			err = c.checkRedirect(req, reqs)
+
+			// Sentinel error to let users select the
+			// previous response, without closing its
+			// body. See Issue 10069.
+			if err == ErrUseLastResponse {
+				return resp, nil
+			}
+
+			// Close the previous response's body. But
+			// read at least some of the body so if it's
+			// small the underlying TCP connection will be
+			// re-used. No need to check for errors: if it
+			// fails, the Transport won't reuse it anyway.
+			const maxBodySlurpSize = 2 << 10
+			if resp.ContentLength == -1 || resp.ContentLength <= maxBodySlurpSize {
+				io.CopyN(io.Discard, resp.Body, maxBodySlurpSize)
+			}
+			resp.Body.Close()
+
+			if err != nil {
+				// Special case for Go 1 compatibility: return both the response
+				// and an error if the CheckRedirect function failed.
+				// See https://golang.org/issue/3795
+				// The resp.Body has already been closed.
+				ue := uerr(err)
+				ue.(*url.Error).URL = loc
+				return resp, ue
+			}
+		}
+
+		reqs = append(reqs, req)
+		var err error
+		var didTimeout func() bool
+		if resp, didTimeout, err = c.send(req, deadline); err != nil {
+			// c.send() always closes req.Body
+			reqBodyClosed = true
+			if !deadline.IsZero() && didTimeout() {
+				// TINYGO: there is no timeoutError type here, so keep the
+				// TINYGO: wrapping that this port always used.
+				err = fmt.Errorf("%s (Client.Timeout exceeded while awaiting headers)", err.Error())
+			}
+			return nil, uerr(err)
+		}
+
+		var shouldRedirect, includeBodyOnHop bool
+		redirectMethod, shouldRedirect, includeBodyOnHop = redirectBehavior(req.Method, resp, reqs[0])
+		if !shouldRedirect {
+			return resp, nil
+		}
+		if !includeBodyOnHop {
+			// Once a hop drops the body, we never send it again
+			// (because we're now handling a redirect for a request with no body).
+			includeBody = false
+		}
+
+		req.closeBody()
+	}
+}
+
+// makeHeadersCopier makes a function that copies headers from the
+// initial Request, ireq. For every redirect, this function must be called
+// so that it can copy headers into the upcoming Request.
+func (c *Client) makeHeadersCopier(ireq *Request) func(req *Request, stripSensitiveHeaders, stripBodyHeaders bool) {
+	// The headers to copy are from the very initial request.
+	// We use a closured callback to keep a reference to these original headers.
+	var (
+		ireqhdr  = cloneOrMakeHeader(ireq.Header)
+		icookies map[string][]*Cookie
+	)
+	if c.Jar != nil && ireq.Header.Get("Cookie") != "" {
+		icookies = make(map[string][]*Cookie)
+		for _, c := range ireq.Cookies() {
+			icookies[c.Name] = append(icookies[c.Name], c)
+		}
 	}
 
-	return resp, nil
+	return func(req *Request, stripSensitiveHeaders, stripBodyHeaders bool) {
+		// If Jar is present and there was some initial cookies provided
+		// via the request header, then we may need to alter the initial
+		// cookies as we follow redirects since each redirect may end up
+		// modifying a pre-existing cookie.
+		//
+		// Since cookies already set in the request header do not contain
+		// information about the original domain and path, the logic below
+		// assumes any new set cookies override the original cookie
+		// regardless of domain or path.
+		//
+		// See https://golang.org/issue/17494
+		if c.Jar != nil && icookies != nil {
+			var changed bool
+			resp := req.Response // The response that caused the upcoming redirect
+			for _, c := range resp.Cookies() {
+				if _, ok := icookies[c.Name]; ok {
+					delete(icookies, c.Name)
+					changed = true
+				}
+			}
+			if changed {
+				ireqhdr.Del("Cookie")
+				var ss []string
+				for _, cs := range icookies {
+					for _, c := range cs {
+						ss = append(ss, c.Name+"="+c.Value)
+					}
+				}
+				slices.Sort(ss) // Ensure deterministic headers
+				ireqhdr.Set("Cookie", strings.Join(ss, "; "))
+			}
+		}
+
+		// Copy the initial request's Header values
+		// (at least the safe ones).
+		for k, vv := range ireqhdr {
+			sensitive := false
+			body := false
+			switch CanonicalHeaderKey(k) {
+			case "Authorization", "Www-Authenticate", "Cookie", "Cookie2",
+				"Proxy-Authorization", "Proxy-Authenticate":
+				sensitive = true
+
+			case "Content-Encoding", "Content-Language", "Content-Location",
+				"Content-Type":
+				// Headers relating to the body which is removed for
+				// POST to GET redirects
+				// https://fetch.spec.whatwg.org/#http-redirect-fetch
+				body = true
+
+			}
+			if !(sensitive && stripSensitiveHeaders) && !(body && stripBodyHeaders) {
+				req.Header[k] = vv
+			}
+		}
+	}
+}
+
+func shouldCopyHeaderOnRedirect(initial, dest *url.URL) bool {
+	// Permit sending auth/cookie headers from "foo.com"
+	// to "sub.foo.com".
+
+	// Note that we don't send all cookies to subdomains
+	// automatically. This function is only used for
+	// Cookies set explicitly on the initial outgoing
+	// client request. Cookies automatically added via the
+	// CookieJar mechanism continue to follow each
+	// cookie's scope as set by Set-Cookie. But for
+	// outgoing requests with the Cookie header set
+	// directly, we don't know their scope, so we assume
+	// it's for *.domain.com.
+
+	// TINYGO: upstream sends both hosts through idnaASCII(), which needs
+	// TINYGO: golang.org/x/net/idna and its tables. This port compares the
+	// TINYGO: hostnames as they are, so the Unicode and the punycode spelling
+	// TINYGO: of one IDN host count as two hosts and lose their sensitive
+	// TINYGO: headers. The rule for a subdomain is the upstream one.
+	ihost := initial.Hostname()
+	dhost := dest.Hostname()
+	return isDomainOrSubdomain(dhost, ihost)
+}
+
+// isDomainOrSubdomain reports whether sub is a subdomain (or exact
+// match) of the parent domain.
+//
+// Both domains must already be in canonical form.
+func isDomainOrSubdomain(sub, parent string) bool {
+	if sub == parent {
+		return true
+	}
+	// If sub contains a :, it's probably an IPv6 address (and is definitely not a hostname).
+	// Don't check the suffix in this case, to avoid matching the contents of a IPv6 zone.
+	// For example, "::1%.www.example.com" is not a subdomain of "www.example.com".
+	if strings.ContainsAny(sub, ":%") {
+		return false
+	}
+	// If sub is "foo.example.com" and parent is "example.com",
+	// that means sub must end in "."+parent.
+	// Do it without allocating.
+	if !strings.HasSuffix(sub, parent) {
+		return false
+	}
+	return sub[len(sub)-len(parent)-1] == '.'
+}
+
+func stripPassword(u *url.URL) string {
+	_, passSet := u.User.Password()
+	if passSet {
+		return strings.Replace(u.String(), u.User.String()+"@", u.User.Username()+":***@", 1)
+	}
+	return u.String()
 }
 
 // Post issues a POST to the specified URL.


### PR DESCRIPTION
# net/http: follow redirects in the client again

Repository **tinygo-org/net**. Branch `upstream-pr/http-redirects`, base `main`.

## What this does

The client keeps `CheckRedirect` and `ErrUseLastResponse`, but `Client.do` lost
its redirect loop, so a 3xx went straight back to the caller with an unread
body. A request for a GitHub release asset returned 302 and zero bytes where Go
returns 200 and the file.

This ports the loop of Go back into `http/client.go`. It has

- up to 10 hops through `checkRedirect` and `defaultCheckRedirect`,
- `redirectBehavior` with the 301, 302 and 303 change to GET and the 307 and 308
  replay with `GetBody`,
- `Location` resolved against the URL of the current request,
- the drop of sensitive headers when a hop leaves the initial domain,
- the read and close of an intermediate body,
- `ErrUseLastResponse` honoured,
- `refererForURL` with the https to http rule.

The code follows the upstream Go source, with its comments, so a later update
from upstream is a straight comparison.

## Two changes from upstream

- `shouldCopyHeaderOnRedirect` compares the hostnames as they are and not
  through `idnaASCII`, which needs `golang.org/x/net/idna` and its tables. The
  Unicode and the punycode spelling of one IDN host thus count as two hosts and
  lose their sensitive headers. That is the safe direction. The rule for a
  subdomain is the upstream one.
- `roundTrip` uses `Request.URL.Host` when `Request.Host` is empty, because only
  `NewRequest` fills `Request.Host` and a redirect hop builds its request
  directly.

## Evidence

There is no CI in this repository. Checked by hand on macOS 26.6 arm64 with a
TinyGo build that carries the matching toolchain change.

- Before, a GET of a GitHub release asset returned 302 and 0 bytes.
- After, the same GET returns 200 and the file.
- A program that does `http.Get("https://example.com/")` builds and completes.

A downstream product ships binaries built with these changes in a production
release. dispat v1.4.0 is published and is not a prerelease. It carries
`dispat-tiny-linux-amd64` and `dispat-tiny-linux-arm64`, built by the fork
release v0.42.0-net.4 from sha256-pinned tarballs and smoke-executed under
binfmt before upload, beside six binaries from the gc toolchain.
<https://github.com/yohimik/dispat/releases/tag/services%2Fdispat%2Fv1.4.0>

The acceptance record of that repository is committed at
`packages/docs/docs/internals/tinygo.md`. It reports the net.2 to net.4
acceptance history, an integration suite of 694 rows that passes with 0 failures
and 1 documented skip on darwin, and a size table of 0.58x to 0.63x against the
gc equivalents with TinyGo `-opt=z -no-debug` against `go build -trimpath
-ldflags "-s -w"`. Those figures come from that document. They are not a
measurement of this branch.

The self-update path of that program downloads a release asset over HTTPS, which
is the redirect case above.

## Scope

- One file, `http/client.go`. No API change.
- The change is independent of the darwin work in this series and applies to
  linux as it stands.

## Known gaps

- `http.Client.Timeout` is still inert in this port. The loop does not add a
  deadline of its own. That is a separate piece of work.
- There is no `Transport` implementation, so a caller-supplied `Transport` is
  still driven directly and does not take part in the redirect handling.

## Related pull requests

This change is part of one body of work. Together the changes make programs that use the network and child processes work on hosted linux and macOS. A full CLI was tested end to end with all of them and ships binaries built this way, see dispat v1.4.0 in the evidence section.

In tinygo-org/tinygo
- tinygo-org/tinygo#5630 sync, RWMutex hand-over. Bug fix, standalone.
- tinygo-org/tinygo#5631 is CLOSED in favor of tinygo-org/tinygo#5530 for signal delivery with the threads scheduler.
- tinygo-org/tinygo#5612 owns darwin fcntl. tinygo-org/tinygo#5632 is closed in its favor. Integer and pointer tests were offered on #5612.
- tinygo-org/tinygo#5633 runtime, weak.runtime_makeStrongFromWeak. Needed by real crypto/tls.
- tinygo-org/tinygo#5634 is limited to process support with posix_spawn.
- tinygo-org/tinygo#5635 loader, real crypto/tls on hosted linux and darwin.
- tinygo-org/tinygo#5636 adds builder socket and spawn symbols at 6fded0c9. It is independent. Its direct syscall test needs no net pin.

In this repository
- #72 net/http, follow redirects in the client again.
- #73 net, report a name that does not exist as a not-found error.
- #74 net, extend the host netdev to darwin.
- #75 net/http, give the HTTPS client trust roots on darwin.

A merge order that works. The remaining bug fixes are independent. tinygo-org/tinygo#5633 goes before tinygo-org/tinygo#5635. HTTPS on linux needs only tinygo-org/tinygo#5633 and tinygo-org/tinygo#5635. Full darwin support also needs tinygo-org/tinygo#5636, the net changes and a new src/net submodule pin.

### Related owner work

- #77 owns Linux I/O cancellation and deadline interruption. Its epoll code needs an OS split when combined with the darwin support in #74.
- #80 owns the kernel-assigned TCP listener port. Do not add a second port fix.
- #79 owns server TLS methods. This is separate from client redirects and client trust roots.
- #67 owns Client.Timeout and transport selection. Its native cancellation gap is recorded in the review. #72 must be combined with that work at http/client.go.
- #78 owns Dialer.Control API fields and other API additions. It does not implement ListenConfig.

The Crier listener and close audit is separate from these PR measurements. The historical Linux arm64 run passed 142 tests with local patches. It predates later Crier changes and is not release validation.


### Current integration status

Darwin fcntl work is in tinygo-org/tinygo#5612. tinygo-org/tinygo#5632 is closed and remains a history reference only. The integer and pointer tests were offered on #5612. Builder socket and spawn symbols in tinygo-org/tinygo#5636 are an independent prerequisite at 6fded0c9. The direct syscall test needs no net update, so that PR does not wait for this net series. tinygo-org/tinygo#5634 is limited to process support.

#82 supplies the separate ListenConfig implementation. Close guard tests and a limited shutdown fix stay on the fork branch codex/close-audit for coordination with the #77 owner. They are not equivalent to the poller. No second shutdown PR was opened.


### Published fork and downstream evidence

[The net.2 fork release](https://github.com/yohimik/tinygo/releases/tag/v0.43.0-net.2) combines the coordinated changes at `95fba82a`, with net `0f460803`. It differs from accepted candidate `e7d34c8c` only in the version constant. Linux, macOS and Windows branch CI and tag CI passed on their first attempts.

Dispat source `909dc401`, with harness `0990c6db`, passed 796 test events with no failures or skips on each native Darwin ARM64 and Linux ARM64 candidate run. Crier source `7d687fc8` passed raw and stripped E2E on native Linux ARM64 and emulated Linux AMD64, each with 144 top-level tests and 156 passing events, no failures or skips. Both applications use TinyGo-built update fixtures and test trusted TLS, certificate refusal, original backup hashes and byte-identical offline rollback. Their workflows also exercise files, environment variables, concurrency and child processes. Crier includes real FFmpeg and webrender/canvas rendering.

Crier's unchanged 13-image pixel gate passed. It uses an approved two-line explicit-rounding webrender build patch for both compilers. The earlier gradient mismatch was permitted fused arithmetic, not a TinyGo compiler error. Candidate stripped sizes are 13,835,824 versus 30,277,794 Go bytes on ARM64 (54.30% smaller), and 16,446,968 versus 32,518,306 on AMD64 (49.42% smaller).

These are combined-candidate application results, not proof that this PR alone supplies the features. They supersede the earlier Crier comparison. Published-toolchain probes and application acceptance have since completed. The final Crier v1.1.1 release evidence is below. Dispat controls its own publication. WaitDelay, in-flight deadlines and full descriptor lifetime remain open. This enables tested CLI client workflows, not general Go or server compatibility.



### Owner sync, 6 September

The owner of #77 adopted our repeated-Close guard as `9dc11e1`, with tests adapted to its nonblocking sockets. The owner of #80 adopted the Zone correction as `7b7aacb` and removed the test dependency on #82. These are PR branches, not upstream merges.

The owner of #83 supplied combined branch `0magnet/net:client-transport-dispatch-72` at `423aacc3`, with #72 first and transport dispatch on top. The source retains the redirect loop and Host fallback. Proposed order is #72, then #83 rebased onto it. The three committed transport tests do not contain the reported redirect and sensitive-header tests, so their commit was requested in [the review reply](https://github.com/tinygo-org/net/pull/83#issuecomment-5561165341). The combined branch has not been independently executed here and is not included in net.2. New #84 uses the existing integer-conversion shim in `tlssock.go` and is also not included. No duplicate PR is needed.

### Published Crier v1.1.1 evidence

[Crier v1.1.1](https://github.com/yohimik/crier/releases/tag/v1.1.1) is public at source `acac2f0e` and uses published TinyGo `0.43.0-net.2`. Its [final acceptance report](https://github.com/yohimik/crier/releases/download/v1.1.1/crier-v1.1.1-acceptance.md) and [SHA-256 manifest](https://github.com/yohimik/crier/releases/download/v1.1.1/SHA256SUMS) identify the exact release bytes. The public tag, asset sizes and report digest were checked. These final sizes supersede the candidate sizes above.

| Linux target | Standard Go bytes | Stripped TinyGo bytes | Reduction |
| --- | ---: | ---: | ---: |
| ARM64 | 30,277,794 | 13,835,840 | 54.30% |
| AMD64 | 32,518,306 | 16,447,000 | 49.42% |

The report records 144 top-level tests and 156 passing events for each raw and stripped run on native ARM64 and emulated AMD64, with no failures or skips. It covers real CLI files, environment and concurrent work, child processes, TLS, update/rollback fixtures, uploads, real FFmpeg, and webrender/canvas rendering. The unchanged 13-image gate passes on both targets. AMD64 is exact; ARM64 has 12 exact images and four event-card pixels with channel difference 1. Both compilers use the same explicit-rounding webrender build patch. Standard Go tests, 90.6% coverage, lint and docs also pass.

This is combined-fork application evidence, not isolated proof for this PR or general server support. The generic emulated AMD64 `os` closure assertions still fail and also fail with ordinary Go under that emulation; they are not counted as passing. Native AMD64 CI and the final published AMD64 `net` package pass. The report retains other platform and deadline/descriptor limits. Tiny binaries are opt-in; normal install/self-update selects standard Go assets.

### Published Dispat v1.8.1 CLI evidence

[Dispat v1.8.1 CLI](https://github.com/yohimik/dispat/releases/tag/services/dispat/v1.8.1) is public. Its [size and SHA-256 manifest](https://github.com/yohimik/dispat/releases/download/services/dispat/v1.8.1/dispat-binary-sizes.json) records build source `40c58236`, Go 1.26.8 and TinyGo `0.43.0-net.2`. The public asset metadata and manifest digest were checked.

| Linux target | Standard Go bytes | TinyGo bytes | Reduction |
| --- | ---: | ---: | ---: |
| ARM64 | 9,896,098 | 6,299,032 | 36.35% |
| AMD64 | 10,895,522 | 6,697,528 | 38.53% |

These are final published CLI asset sizes, not the earlier candidate measurements. They do not replace the separately identified test evidence or remove known runtime limits. The [full release workflow](https://github.com/yohimik/dispat/actions/runs/34054341541) has now completed successfully at the recorded build source, including its Windows, macOS and Ubuntu checks. This does not change the test and platform limits stated above.


