### PR TITLE
net: report a name that does not exist as a not-found lookup error

### DIFF
--- a/lookup.go
+++ b/lookup.go
@@ -59,7 +59,7 @@ func (r *Resolver) LookupHost(ctx context.Context, host string) (addrs []string,
 	}
 	ip, err := netdev.GetHostByName(host)
 	if err != nil {
-		return nil, &DNSError{Err: err.Error(), Name: host}
+		return nil, newLookupError(host, err)
 	}
 	return []string{ip.String()}, nil
 }
@@ -88,7 +88,7 @@ func (r *Resolver) LookupIPAddr(ctx context.Context, host string) ([]IPAddr, err
 	}
 	ip, err := netdev.GetHostByName(host)
 	if err != nil {
-		return nil, &DNSError{Err: err.Error(), Name: host}
+		return nil, newLookupError(host, err)
 	}
 	return []IPAddr{{IP: ip.AsSlice(), Zone: ip.Zone()}}, nil
 }
@@ -104,7 +104,7 @@ func (r *Resolver) LookupNetIP(ctx context.Context, network, host string) ([]net
 	}
 	ip, err := netdev.GetHostByName(host)
 	if err != nil {
-		return nil, &DNSError{Err: err.Error(), Name: host}
+		return nil, newLookupError(host, err)
 	}
 	return []netip.Addr{ip}, nil
 }
@@ -149,3 +149,23 @@ func (r *Resolver) LookupTXT(ctx context.Context, name string) ([]string, error)
 
 // errNoSuchHost is returned when the host lookup finds no matching records.
 var errNoSuchHost = errors.New("no such host")
+
+// newLookupError wraps a netdev resolver error in a DNSError for host.
+//
+// TINYGO: the netdev can report a DNSError of its own, and callers read
+// IsNotFound and IsTimeout on the outer error, so carry those flags out.
+func newLookupError(host string, err error) *DNSError {
+	dnsErr := &DNSError{Err: err.Error(), Name: host, UnwrapErr: err}
+	if inner, ok := err.(*DNSError); ok {
+		// Take the inner description and not its Error(), which repeats the
+		// "lookup <host>" prefix that this error adds.
+		dnsErr.Err = inner.Err
+		dnsErr.IsNotFound = inner.IsNotFound
+		dnsErr.IsTimeout = inner.IsTimeout
+		dnsErr.IsTemporary = inner.IsTemporary
+		if inner.Server != "" {
+			dnsErr.Server = inner.Server
+		}
+	}
+	return dnsErr
+}

--- a/netdev_native.go
+++ b/netdev_native.go
@@ -379,13 +379,25 @@ const (
 // dnsLookup resolves name by querying the system nameservers over UDP,
 // preferring an IPv4 (A) answer and falling back to IPv6 (AAAA).
 func dnsLookup(name string) (netip.Addr, error) {
-	if addr, err := dnsLookupType(name, dnsTypeA); err == nil {
+	addr, errA := dnsLookupType(name, dnsTypeA)
+	if errA == nil {
 		return addr, nil
 	}
-	if addr, err := dnsLookupType(name, dnsTypeAAAA); err == nil {
+	addr, errAAAA := dnsLookupType(name, dnsTypeAAAA)
+	if errAAAA == nil {
 		return addr, nil
 	}
-	return netip.Addr{}, &DNSError{Err: "no address found", Name: name}
+	// A name that the servers answered NXDOMAIN for is a different condition
+	// from a name that they did not answer at all.
+	notFound := isNotFoundErr(errA) && isNotFoundErr(errAAAA)
+	return netip.Addr{}, &DNSError{Err: "no address found", Name: name, IsNotFound: notFound}
+}
+
+// isNotFoundErr reports whether err is a DNSError for a name or a record type
+// that does not exist.
+func isNotFoundErr(err error) bool {
+	dnsErr, ok := err.(*DNSError)
+	return ok && dnsErr.IsNotFound
 }
 
 // dnsLookupType resolves name for a single DNS record type (A or AAAA).


### PR DESCRIPTION
# net: report a name that does not exist as a not-found lookup error

Repository **tinygo-org/net**. Branch `upstream-pr/dns-not-found`, base `main`.

## What this does

The resolver learns from an NXDOMAIN reply that the name does not exist, but
both layers above it lost that fact.

- `dnsLookup` in `netdev_native.go` replaced the error with a generic "no
  address found".
- The `Resolver` methods in `lookup.go` built the `DNSError` from the message
  alone.

A caller that reads `DNSError.IsNotFound`, to tell "no such host" from "the
resolver did not answer", thus never saw a not-found lookup. A command line
program that must tell a typo in a host name from an offline network cannot do
so.

The change carries the flag out through both layers.

- `dnsLookup` reports not-found when the A query and the AAAA query both said
  so.
- The `Resolver` methods copy `IsNotFound`, `IsTimeout` and `IsTemporary` from
  the `DNSError` of the netdev, keep it as the unwrap target, and take its
  description and not its `Error()`, which repeats the "lookup <host>" prefix.

## Evidence

There is no CI in this repository. Checked by hand on macOS 26.6 arm64 with a
TinyGo build that carries the matching toolchain change. A lookup of a name that
does not exist now returns a `DNSError` with `IsNotFound` true, and a lookup
with no reachable resolver returns one with `IsNotFound` false.

A downstream product ships binaries built with these changes in a production
release. dispat v1.4.0 is published and is not a prerelease. It carries
`dispat-tiny-linux-amd64` and `dispat-tiny-linux-arm64`, built by the fork
release v0.42.0-net.4 from sha256-pinned tarballs and smoke-executed under
binfmt before upload, beside six binaries from the gc toolchain.
<https://github.com/yohimik/dispat/releases/tag/services%2Fdispat%2Fv1.4.0>

The acceptance record of that repository is committed at
`packages/docs/docs/internals/tinygo.md`. It reports the net.2 to net.4
acceptance history, an integration suite of 694 rows that passes with 0 failures
and 1 documented skip on darwin, and a size table of 0.58x to 0.63x against the
gc equivalents with TinyGo `-opt=z -no-debug` against `go build -trimpath
-ldflags "-s -w"`. Those figures come from that document. They are not a
measurement of this branch.

The suite of that repository has rows that read `IsNotFound` to give the user
the right message.

## Scope

- Two files. No API change. The behaviour for a lookup that succeeds is the
  same.
- The change is independent of the darwin netdev work and applies to linux as
  it stands.

## Related

- tinygo-org/net#28, "Support for x86_64 Linux".

## Related pull requests

This change is part of one body of work. Together the changes make programs that use the network and child processes work on hosted linux and macOS. A full CLI was tested end to end with all of them and ships binaries built this way, see dispat v1.4.0 in the evidence section.

In tinygo-org/tinygo
- tinygo-org/tinygo#5630 sync, RWMutex hand-over. Bug fix, standalone.
- tinygo-org/tinygo#5631 is CLOSED in favor of tinygo-org/tinygo#5530 for signal delivery with the threads scheduler.
- tinygo-org/tinygo#5612 owns darwin fcntl. tinygo-org/tinygo#5632 is closed in its favor. Integer and pointer tests were offered on #5612.
- tinygo-org/tinygo#5633 runtime, weak.runtime_makeStrongFromWeak. Needed by real crypto/tls.
- tinygo-org/tinygo#5634 is limited to process support with posix_spawn.
- tinygo-org/tinygo#5635 loader, real crypto/tls on hosted linux and darwin.
- tinygo-org/tinygo#5636 adds builder socket and spawn symbols at 6fded0c9. It is independent. Its direct syscall test needs no net pin.

In this repository
- #72 net/http, follow redirects in the client again.
- #73 net, report a name that does not exist as a not-found error.
- #74 net, extend the host netdev to darwin.
- #75 net/http, give the HTTPS client trust roots on darwin.

A merge order that works. The remaining bug fixes are independent. tinygo-org/tinygo#5633 goes before tinygo-org/tinygo#5635. HTTPS on linux needs only tinygo-org/tinygo#5633 and tinygo-org/tinygo#5635. Full darwin support also needs tinygo-org/tinygo#5636, the net changes and a new src/net submodule pin.

### Related owner work

- #77 owns Linux I/O cancellation and deadline interruption. Its epoll code needs an OS split when combined with the darwin support in #74.
- #80 owns the kernel-assigned TCP listener port. Do not add a second port fix.
- #79 owns server TLS methods. This is separate from client redirects and client trust roots.
- #67 owns Client.Timeout and transport selection. Its native cancellation gap is recorded in the review. #72 must be combined with that work at http/client.go.
- #78 owns Dialer.Control API fields and other API additions. It does not implement ListenConfig.

The Crier listener and close audit is separate from these PR measurements. The historical Linux arm64 run passed 142 tests with local patches. It predates later Crier changes and is not release validation.


### Current integration status

Darwin fcntl work is in tinygo-org/tinygo#5612. tinygo-org/tinygo#5632 is closed and remains a history reference only. The integer and pointer tests were offered on #5612. Builder socket and spawn symbols in tinygo-org/tinygo#5636 are an independent prerequisite at 6fded0c9. The direct syscall test needs no net update, so that PR does not wait for this net series. tinygo-org/tinygo#5634 is limited to process support.

#82 supplies the separate ListenConfig implementation. Close guard tests and a limited shutdown fix stay on the fork branch codex/close-audit for coordination with the #77 owner. They are not equivalent to the poller. No second shutdown PR was opened.


### Published fork and downstream evidence

[The net.2 fork release](https://github.com/yohimik/tinygo/releases/tag/v0.43.0-net.2) combines the coordinated changes at `95fba82a`, with net `0f460803`. It differs from accepted candidate `e7d34c8c` only in the version constant. Linux, macOS and Windows branch CI and tag CI passed on their first attempts.

Dispat source `909dc401`, with harness `0990c6db`, passed 796 test events with no failures or skips on each native Darwin ARM64 and Linux ARM64 candidate run. Crier source `7d687fc8` passed raw and stripped E2E on native Linux ARM64 and emulated Linux AMD64, each with 144 top-level tests and 156 passing events, no failures or skips. Both applications use TinyGo-built update fixtures and test trusted TLS, certificate refusal, original backup hashes and byte-identical offline rollback. Their workflows also exercise files, environment variables, concurrency and child processes. Crier includes real FFmpeg and webrender/canvas rendering.

Crier's unchanged 13-image pixel gate passed. It uses an approved two-line explicit-rounding webrender build patch for both compilers. The earlier gradient mismatch was permitted fused arithmetic, not a TinyGo compiler error. Candidate stripped sizes are 13,835,824 versus 30,277,794 Go bytes on ARM64 (54.30% smaller), and 16,446,968 versus 32,518,306 on AMD64 (49.42% smaller).

These are combined-candidate application results, not proof that this PR alone supplies the features. They supersede the earlier Crier comparison. Published-toolchain probes and application acceptance have since completed. The final Crier v1.1.1 release evidence is below. Dispat controls its own publication. WaitDelay, in-flight deadlines and full descriptor lifetime remain open. This enables tested CLI client workflows, not general Go or server compatibility.



### Owner sync, 6 September

The owner of #77 adopted our repeated-Close guard as `9dc11e1`, with tests adapted to its nonblocking sockets. The owner of #80 adopted the Zone correction as `7b7aacb` and removed the test dependency on #82. These are PR branches, not upstream merges.

New #83 restores RoundTripper dispatch. A Git merge check against #72 reports a conflict in `http/client.go`; both behaviors need combined tests before integration. New #84 uses the existing integer-conversion shim in `tlssock.go`. Neither new PR is included in the tested candidate `e7d34c8c`. No duplicate PR is needed.

### Published Crier v1.1.1 evidence

[Crier v1.1.1](https://github.com/yohimik/crier/releases/tag/v1.1.1) is public at source `acac2f0e` and uses published TinyGo `0.43.0-net.2`. Its [final acceptance report](https://github.com/yohimik/crier/releases/download/v1.1.1/crier-v1.1.1-acceptance.md) and [SHA-256 manifest](https://github.com/yohimik/crier/releases/download/v1.1.1/SHA256SUMS) identify the exact release bytes. The public tag, asset sizes and report digest were checked. These final sizes supersede the candidate sizes above.

| Linux target | Standard Go bytes | Stripped TinyGo bytes | Reduction |
| --- | ---: | ---: | ---: |
| ARM64 | 30,277,794 | 13,835,840 | 54.30% |
| AMD64 | 32,518,306 | 16,447,000 | 49.42% |

The report records 144 top-level tests and 156 passing events for each raw and stripped run on native ARM64 and emulated AMD64, with no failures or skips. It covers real CLI files, environment and concurrent work, child processes, TLS, update/rollback fixtures, uploads, real FFmpeg, and webrender/canvas rendering. The unchanged 13-image gate passes on both targets. AMD64 is exact; ARM64 has 12 exact images and four event-card pixels with channel difference 1. Both compilers use the same explicit-rounding webrender build patch. Standard Go tests, 90.6% coverage, lint and docs also pass.

This is combined-fork application evidence, not isolated proof for this PR or general server support. The generic emulated AMD64 `os` closure assertions still fail and also fail with ordinary Go under that emulation; they are not counted as passing. Native AMD64 CI and the final published AMD64 `net` package pass. The report retains other platform and deadline/descriptor limits. Tiny binaries are opt-in; normal install/self-update selects standard Go assets.

### Published Dispat v1.8.1 CLI evidence

[Dispat v1.8.1 CLI](https://github.com/yohimik/dispat/releases/tag/services/dispat/v1.8.1) is public. Its [size and SHA-256 manifest](https://github.com/yohimik/dispat/releases/download/services/dispat/v1.8.1/dispat-binary-sizes.json) records build source `40c58236`, Go 1.26.8 and TinyGo `0.43.0-net.2`. The public asset metadata and manifest digest were checked.

| Linux target | Standard Go bytes | TinyGo bytes | Reduction |
| --- | ---: | ---: | ---: |
| ARM64 | 9,896,098 | 6,299,032 | 36.35% |
| AMD64 | 10,895,522 | 6,697,528 | 38.53% |

These are final published CLI asset sizes, not the earlier candidate measurements. They do not replace the separately identified test evidence or remove known runtime limits. The [full release workflow](https://github.com/yohimik/dispat/actions/runs/34054341541) has now completed successfully at the recorded build source, including its Windows, macOS and Ubuntu checks. This does not change the test and platform limits stated above.


