### PR TITLE
net: extend the host netdev to darwin

### DIFF
--- a/netdev_native.go
+++ b/netdev_native.go
@@ -1,17 +1,21 @@
-//go:build linux && !baremetal && !nintendoswitch && !wasm_unknown && !tinygo.wasm
+//go:build (linux || darwin) && !baremetal && !nintendoswitch && !wasm_unknown && !tinygo.wasm
 
-// TINYGO: Native (host) netdev for the TinyGo "linux" target.
+// TINYGO: Native (host) netdev for the TinyGo "linux" and "darwin" targets.
 //
-// On the native linux target TinyGo does NOT override the "syscall" package, so
-// the standard library's syscall.Socket/Connect/Bind/... are available and the
-// TinyGo compiler lowers syscall.Syscall/RawSyscall into real inline-asm system
-// calls (see compiler/syscall.go). That means we can implement the netdever
-// interface directly on top of raw Linux sockets, without needing a network
-// driver or musl's (omitted) src/network module.
+// On those native targets TinyGo does NOT override the "syscall" package, so
+// the standard library's syscall.Socket/Connect/Bind/... are available: on
+// linux the TinyGo compiler lowers syscall.Syscall/RawSyscall into real
+// inline-asm system calls, and on darwin it routes the libc_*_trampoline
+// symbols to libSystem (see compiler/syscall.go). Either way we can implement
+// the netdever interface directly on top of raw host sockets, without needing a
+// network driver or musl's (omitted) src/network module.
 //
 // This file registers that implementation as the default netdev, so that
-// net.Dial/Listen/Lookup just work on a regular Linux host. See
+// net.Dial/Listen/Lookup just work on a regular Linux or macOS host. See
 // https://github.com/skycoin/skycoin/issues/2902.
+//
+// The per-OS socket defaults are in netdev_native_linux.go and
+// netdev_native_darwin.go. Everything else here is common to the two.
 
 package net
 
@@ -31,7 +35,7 @@ func init() {
 	useNetdev(&hostNetdev{})
 }
 
-// hostNetdev implements netdever using raw Linux sockets via the syscall
+// hostNetdev implements netdever using raw host sockets via the syscall
 // package. The "sockfd" values it returns are plain OS file descriptors.
 //
 // Deadlines are implemented with the per-socket SO_RCVTIMEO/SO_SNDTIMEO
@@ -95,11 +99,7 @@ func (*hostNetdev) Socket(domain, stype, protocol int) (int, error) {
 		return -1, err
 	}
 
-	// Allow quick rebind of listening sockets (e.g. restarting a server),
-	// matching the standard library's behaviour.
-	if stype == syscall.SOCK_STREAM {
-		syscall.SetsockoptInt(fd, syscall.SOL_SOCKET, syscall.SO_REUSEADDR, 1)
-	}
+	setSockDefaults(fd, stype)
 
 	return fd, nil
 }
@@ -133,10 +133,22 @@ func (*hostNetdev) Listen(sockfd int, backlog int) error {
 }
 
 func (*hostNetdev) Accept(sockfd int) (int, netip.AddrPort, error) {
-	nfd, sa, err := syscall.Accept(sockfd)
+	var nfd int
+	var sa syscall.Sockaddr
+	var err error
+	for {
+		// A signal from the runtime interrupts a blocking accept, so retry
+		// instead of a report of a failure that the caller cannot act on.
+		nfd, sa, err = syscall.Accept(sockfd)
+		if err == syscall.EINTR {
+			continue
+		}
+		break
+	}
 	if err != nil {
 		return -1, netip.AddrPort{}, err
 	}
+	setSockDefaults(nfd, syscall.SOCK_STREAM)
 	var raddr netip.AddrPort
 	switch s := sa.(type) {
 	case *syscall.SockaddrInet4:

--- a/netdev_native_darwin.go
+++ b/netdev_native_darwin.go
@@ -1,0 +1,16 @@
+//go:build darwin && !baremetal && !nintendoswitch && !wasm_unknown && !tinygo.wasm
+
+package net
+
+import "syscall"
+
+// setSockDefaults applies the socket options that the host netdev wants on
+// every socket. SO_REUSEADDR allows a quick rebind of a listening socket, as on
+// linux. SO_NOSIGPIPE is necessary because a BSD socket raises SIGPIPE on a
+// write to a closed connection and darwin has no MSG_NOSIGNAL.
+func setSockDefaults(fd int, stype int) {
+	if stype == syscall.SOCK_STREAM {
+		syscall.SetsockoptInt(fd, syscall.SOL_SOCKET, syscall.SO_REUSEADDR, 1)
+	}
+	syscall.SetsockoptInt(fd, syscall.SOL_SOCKET, syscall.SO_NOSIGPIPE, 1)
+}

--- a/netdev_native_linux.go
+++ b/netdev_native_linux.go
@@ -1,0 +1,15 @@
+//go:build linux && !baremetal && !nintendoswitch && !wasm_unknown && !tinygo.wasm
+
+package net
+
+import "syscall"
+
+// setSockDefaults applies the socket options that the host netdev wants on
+// every socket. On linux that is only SO_REUSEADDR on a stream socket, which
+// allows a quick rebind of a listening socket. This is the same set of options
+// that the netdev applied before the darwin split.
+func setSockDefaults(fd int, stype int) {
+	if stype == syscall.SOCK_STREAM {
+		syscall.SetsockoptInt(fd, syscall.SOL_SOCKET, syscall.SO_REUSEADDR, 1)
+	}
+}


### PR DESCRIPTION
# net: extend the host netdev to darwin

Repository **tinygo-org/net**. Branch `upstream-pr/darwin-host-netdev`, base
`main`.

## What this does

The host netdev was for linux only, so a macOS binary registered no netdev and
every `Dial` reported "Netdev not set". Nothing in it is specific to linux.
Darwin also keeps the standard library `syscall` package, where the TinyGo
compiler routes the `libc_*_trampoline` symbols to libSystem, so the same
raw-socket implementation works there.

- The build constraint on `netdev_native.go` becomes `(linux || darwin)`.
- The one part that is different, the socket options for every socket, moves
  into per-OS `setSockDefaults` functions in `netdev_native_linux.go` and
  `netdev_native_darwin.go`.
- Linux keeps the same `SO_REUSEADDR` as before. Darwin adds `SO_NOSIGPIPE`,
  because a BSD socket raises SIGPIPE on a write to a closed connection and
  darwin has no `MSG_NOSIGNAL` to prevent it for one write. Without it a peer
  that hangs up in the middle of a response kills the process instead of a
  return of EPIPE from `Send`.
- `Accept` retries on EINTR, as `Connect`, `Send` and `Recv` already do. Under
  the threads scheduler a GC cycle interrupts a blocking call with a signal, and
  a server must not see that as a failed accept.
- An accepted socket gets the same defaults as a created one, which puts
  `SO_NOSIGPIPE` on the connections that a server writes to.

## Evidence

There is no CI in this repository, so the checks were run by hand on macOS 26.6
arm64 with a TinyGo build that carries the matching toolchain change.

- A program that calls `net.LookupHost` and `http.Get("https://example.com/")`
  builds and completes with this branch and the three other branches in this
  series.

A downstream product ships binaries built with these changes in a production
release. dispat v1.4.0 is published and is not a prerelease. It carries
`dispat-tiny-linux-amd64` and `dispat-tiny-linux-arm64`, built by the fork
release v0.42.0-net.4 from sha256-pinned tarballs and smoke-executed under
binfmt before upload, beside six binaries from the gc toolchain.
<https://github.com/yohimik/dispat/releases/tag/services%2Fdispat%2Fv1.4.0>

The acceptance record of that repository is committed at
`packages/docs/docs/internals/tinygo.md`. It reports the net.2 to net.4
acceptance history, an integration suite of 694 rows that passes with 0 failures
and 1 documented skip on darwin, and a size table of 0.58x to 0.63x against the
gc equivalents with TinyGo `-opt=z -no-debug` against `go build -trimpath
-ldflags "-s -w"`. Those figures come from that document. They are not a
measurement of this branch.

The rows of that suite include DNS, TCP, TLS and x509 paths. The shipped
binaries in that release are for linux. The darwin evidence is the acceptance
record and the check above.

## Dependencies

- The darwin toolchain needs the BSD socket symbols in the libSystem stub. See
  the tinygo PR "builder: declare the BSD socket API in the darwin libSystem
  stub". Without it a darwin program that opens a socket does not link.

## Known gaps

- Deadlines use `SO_RCVTIMEO` and `SO_SNDTIMEO`, and a call that EINTR restarts
  begins its timeout again, so a deadline can be later than it should be under a
  heavy GC load.
- Linux behaviour is unchanged.

## Related

- tinygo-org/net#28, "Support for x86_64 Linux".
- tinygo-org/tinygo#4981, "Netdev not set on AMD64+Linux".
- tinygo-org/tinygo#4630, "the network does not work without drivers?".
- tinygo-org/tinygo#1776, "TinyGo, TCP/UDP, Linux".
- tinygo-org/tinygo#5205, "Missing stdlib symbols on Linux native".

## Related pull requests

This change is part of one body of work. Together the changes make programs that use the network and child processes work on hosted linux and macOS. A full CLI was tested end to end with all of them and ships binaries built this way, see dispat v1.4.0 in the evidence section.

In tinygo-org/tinygo
- tinygo-org/tinygo#5630 sync, RWMutex hand-over. Bug fix, standalone.
- tinygo-org/tinygo#5631 is CLOSED in favor of tinygo-org/tinygo#5530 for signal delivery with the threads scheduler.
- tinygo-org/tinygo#5612 owns darwin fcntl. tinygo-org/tinygo#5632 is closed in its favor. Integer and pointer tests were offered on #5612.
- tinygo-org/tinygo#5633 runtime, weak.runtime_makeStrongFromWeak. Needed by real crypto/tls.
- tinygo-org/tinygo#5634 is limited to process support with posix_spawn.
- tinygo-org/tinygo#5635 loader, real crypto/tls on hosted linux and darwin.
- tinygo-org/tinygo#5636 adds builder socket and spawn symbols at 6fded0c9. It is independent. Its direct syscall test needs no net pin.

In this repository
- #72 net/http, follow redirects in the client again.
- #73 net, report a name that does not exist as a not-found error.
- #74 net, extend the host netdev to darwin.
- #75 net/http, give the HTTPS client trust roots on darwin.

A merge order that works. The remaining bug fixes are independent. tinygo-org/tinygo#5633 goes before tinygo-org/tinygo#5635. HTTPS on linux needs only tinygo-org/tinygo#5633 and tinygo-org/tinygo#5635. Full darwin support also needs tinygo-org/tinygo#5636, the net changes and a new src/net submodule pin.

### Related owner work

- #77 owns Linux I/O cancellation and deadline interruption. Its epoll code needs an OS split when combined with the darwin support in #74.
- #80 owns the kernel-assigned TCP listener port. Do not add a second port fix.
- #79 owns server TLS methods. This is separate from client redirects and client trust roots.
- #67 owns Client.Timeout and transport selection. Its native cancellation gap is recorded in the review. #72 must be combined with that work at http/client.go.
- #78 owns Dialer.Control API fields and other API additions. It does not implement ListenConfig.

The Crier listener and close audit is separate from these PR measurements. The historical Linux arm64 run passed 142 tests with local patches. It predates later Crier changes and is not release validation.


### Current integration status

Darwin fcntl work is in tinygo-org/tinygo#5612. tinygo-org/tinygo#5632 is closed and remains a history reference only. The integer and pointer tests were offered on #5612. Builder socket and spawn symbols in tinygo-org/tinygo#5636 are an independent prerequisite at 6fded0c9. The direct syscall test needs no net update, so that PR does not wait for this net series. tinygo-org/tinygo#5634 is limited to process support.

#82 supplies the separate ListenConfig implementation. Close guard tests and a limited shutdown fix stay on the fork branch codex/close-audit for coordination with the #77 owner. They are not equivalent to the poller. No second shutdown PR was opened.


### Published fork and downstream evidence

[The net.2 fork release](https://github.com/yohimik/tinygo/releases/tag/v0.43.0-net.2) combines the coordinated changes at `95fba82a`, with net `0f460803`. It differs from accepted candidate `e7d34c8c` only in the version constant. Linux, macOS and Windows branch CI and tag CI passed on their first attempts.

Dispat source `909dc401`, with harness `0990c6db`, passed 796 test events with no failures or skips on each native Darwin ARM64 and Linux ARM64 candidate run. Crier source `7d687fc8` passed raw and stripped E2E on native Linux ARM64 and emulated Linux AMD64, each with 144 top-level tests and 156 passing events, no failures or skips. Both applications use TinyGo-built update fixtures and test trusted TLS, certificate refusal, original backup hashes and byte-identical offline rollback. Their workflows also exercise files, environment variables, concurrency and child processes. Crier includes real FFmpeg and webrender/canvas rendering.

Crier's unchanged 13-image pixel gate passed. It uses an approved two-line explicit-rounding webrender build patch for both compilers. The earlier gradient mismatch was permitted fused arithmetic, not a TinyGo compiler error. Candidate stripped sizes are 13,835,824 versus 30,277,794 Go bytes on ARM64 (54.30% smaller), and 16,446,968 versus 32,518,306 on AMD64 (49.42% smaller).

These are combined-candidate application results, not proof that this PR alone supplies the features. They supersede the earlier Crier comparison. Published-toolchain probes and application acceptance have since completed. The final Crier v1.1.1 release evidence is below. Dispat controls its own publication. WaitDelay, in-flight deadlines and full descriptor lifetime remain open. This enables tested CLI client workflows, not general Go or server compatibility.



### Owner sync, 6 September

The owner of #77 adopted our repeated-Close guard as `9dc11e1`, with tests adapted to its nonblocking sockets. The owner of #80 adopted the Zone correction as `7b7aacb` and removed the test dependency on #82. These are PR branches, not upstream merges.

New #83 restores RoundTripper dispatch. A Git merge check against #72 reports a conflict in `http/client.go`; both behaviors need combined tests before integration. New #84 uses the existing integer-conversion shim in `tlssock.go`. Neither new PR is included in the tested candidate `e7d34c8c`. No duplicate PR is needed.

### Published Crier v1.1.1 evidence

[Crier v1.1.1](https://github.com/yohimik/crier/releases/tag/v1.1.1) is public at source `acac2f0e` and uses published TinyGo `0.43.0-net.2`. Its [final acceptance report](https://github.com/yohimik/crier/releases/download/v1.1.1/crier-v1.1.1-acceptance.md) and [SHA-256 manifest](https://github.com/yohimik/crier/releases/download/v1.1.1/SHA256SUMS) identify the exact release bytes. The public tag, asset sizes and report digest were checked. These final sizes supersede the candidate sizes above.

| Linux target | Standard Go bytes | Stripped TinyGo bytes | Reduction |
| --- | ---: | ---: | ---: |
| ARM64 | 30,277,794 | 13,835,840 | 54.30% |
| AMD64 | 32,518,306 | 16,447,000 | 49.42% |

The report records 144 top-level tests and 156 passing events for each raw and stripped run on native ARM64 and emulated AMD64, with no failures or skips. It covers real CLI files, environment and concurrent work, child processes, TLS, update/rollback fixtures, uploads, real FFmpeg, and webrender/canvas rendering. The unchanged 13-image gate passes on both targets. AMD64 is exact; ARM64 has 12 exact images and four event-card pixels with channel difference 1. Both compilers use the same explicit-rounding webrender build patch. Standard Go tests, 90.6% coverage, lint and docs also pass.

This is combined-fork application evidence, not isolated proof for this PR or general server support. The generic emulated AMD64 `os` closure assertions still fail and also fail with ordinary Go under that emulation; they are not counted as passing. Native AMD64 CI and the final published AMD64 `net` package pass. The report retains other platform and deadline/descriptor limits. Tiny binaries are opt-in; normal install/self-update selects standard Go assets.

### Published Dispat v1.8.1 CLI evidence

[Dispat v1.8.1 CLI](https://github.com/yohimik/dispat/releases/tag/services/dispat/v1.8.1) is public. Its [size and SHA-256 manifest](https://github.com/yohimik/dispat/releases/download/services/dispat/v1.8.1/dispat-binary-sizes.json) records build source `40c58236`, Go 1.26.8 and TinyGo `0.43.0-net.2`. The public asset metadata and manifest digest were checked.

| Linux target | Standard Go bytes | TinyGo bytes | Reduction |
| --- | ---: | ---: | ---: |
| ARM64 | 9,896,098 | 6,299,032 | 36.35% |
| AMD64 | 10,895,522 | 6,697,528 | 38.53% |

These are final published CLI asset sizes, not the earlier candidate measurements. They do not replace the separately identified test evidence or remove known runtime limits. The [full release workflow](https://github.com/yohimik/dispat/actions/runs/34054341541) has now completed successfully at the recorded build source, including its Windows, macOS and Ubuntu checks. This does not change the test and platform limits stated above.


