### PR TITLE
net: add FileListener/FileConn (stubs)

### DIFF
--- a/file.go
+++ b/file.go
@@ -1,0 +1,25 @@
+package net
+
+import (
+	"errors"
+	"os"
+)
+
+// TINYGO: The netdev-based net package manages its own file descriptors and
+// cannot adopt an arbitrary OS file descriptor, so the File* constructors are
+// not implemented. They exist so that packages referencing them (e.g. gin's
+// RunFd helper) compile; callers that actually use them get a clear error.
+
+var errFileNotImplemented = errors.New("net: File-based listeners/conns are not implemented on this target")
+
+// FileListener returns a copy of the network listener corresponding to the open
+// file f.
+func FileListener(f *os.File) (ln Listener, err error) {
+	return nil, errFileNotImplemented
+}
+
+// FileConn returns a copy of the network connection corresponding to the open
+// file f.
+func FileConn(f *os.File) (c Conn, err error) {
+	return nil, errFileNotImplemented
+}

--- a/file.go
+++ b/file.go
@@ -23,3 +23,13 @@ func FileListener(f *os.File) (ln Listener, err error) {
 func FileConn(f *os.File) (c Conn, err error) {
 	return nil, errFileNotImplemented
 }
+
+// File returns a copy of the underlying os.File.
+//
+// TINYGO: same as the constructors above, the other way round — a listener
+// here has no OS file descriptor to hand back. fasthttp's prefork helper
+// calls this to pass a listener to a child process, which neither this net
+// package nor a wasm target can do.
+func (l *TCPListener) File() (f *os.File, err error) {
+	return nil, errFileNotImplemented
+}


### PR DESCRIPTION
Packages like gin reference `net.FileListener` (its `RunFd` helper). The netdev-based net package manages its own file descriptors and cannot adopt an arbitrary OS fd, so these return a clear error rather than being absent — enough to let such packages compile, with a descriptive failure for callers that actually invoke them.

Verified: a program calling both gets `net: File-based listeners/conns are not implemented on this target` rather than a compile error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C3X3gvq8ZggMRvzVzWm66i