### PR TITLE
net: API-compat fills for grpc and wazero (SyscallConn, Dialer.Control, IPConn.Read)

### DIFF
--- a/dial.go
+++ b/dial.go
@@ -94,6 +94,19 @@ type Dialer struct {
 	// netdev-backed ResolveTCPAddr/ResolveUDPAddr and does not consult this
 	// field.
 	Resolver *Resolver
+
+	// Control, if not nil, is called after creating the network connection but
+	// before actually dialing.
+	//
+	// TINYGO: present for API compatibility (callers such as google.golang.org/
+	// grpc set it); the netdev-backed dial does not expose a raw syscall.RawConn,
+	// so this field is not invoked.
+	Control func(network, address string, c syscall.RawConn) error
+
+	// ControlContext is like Control but additionally receives the context.
+	//
+	// TINYGO: present for API compatibility; not invoked (see Control).
+	ControlContext func(ctx context.Context, network, address string, c syscall.RawConn) error
 }
 
 // Dial connects to the address on the named network.

--- a/iprawsock.go
+++ b/iprawsock.go
@@ -120,6 +120,13 @@ func (c *IPConn) ReadFrom(b []byte) (int, Addr, error) {
 	return 0, nil, errors.New("ReadFrom not implemented")
 }
 
+// Read implements io.Reader / net.Conn. IPConn was missing it, which broke
+// callers that type-switch it as an io.Reader (e.g. google.golang.org/grpc).
+func (c *IPConn) Read(b []byte) (int, error) {
+	n, _, err := c.ReadFrom(b)
+	return n, err
+}
+
 // WriteToIP acts like WriteTo but takes an IPAddr.
 func (c *IPConn) WriteToIP(b []byte, addr *IPAddr) (int, error) {
 	return 0, errors.New("WriteToIP not implemented")

--- a/tcpsock.go
+++ b/tcpsock.go
@@ -463,3 +463,11 @@ func (l *TCPListener) AcceptTCP() (*TCPConn, error) {
 func (l *TCPListener) SetDeadline(t time.Time) error {
 	return nil
 }
+
+// SyscallConn returns a raw network connection.
+// This implements the [syscall.Conn] interface. It mirrors the TCPConn stub —
+// TCPListener was missing it, so callers that require syscall.Conn (e.g.
+// github.com/tetratelabs/wazero's socket layer) failed to compile.
+func (l *TCPListener) SyscallConn() (syscall.RawConn, error) {
+	return nil, errors.New("SyscallConn not implemented")
+}


### PR DESCRIPTION
Three small source-compatibility fills, surfaced compiling larger Go programs (grpc, wazero) under TinyGo:

- `TCPListener.SyscallConn`: mirror the existing `TCPConn` stub; wazero's socket layer requires `syscall.Conn`.
- `Dialer.Control` + `ControlContext`: API-compat fields grpc sets (not invoked; the netdev dial exposes no raw `syscall.RawConn`).
- `IPConn.Read`: delegate to `ReadFrom` so `IPConn` satisfies `io.Reader` (grpc type-switches on it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C3X3gvq8ZggMRvzVzWm66i