### PR TITLE
net/http: add ListenAndServeTLS / ServeTLS (software TLS)

### DIFF
--- a/http/server.go
+++ b/http/server.go
@@ -3260,6 +3260,57 @@ func ListenAndServe(addr string, handler Handler) error {
 	return server.ListenAndServe()
 }
 
+// ServeTLS accepts incoming HTTPS connections on the listener l, wrapping each
+// with a TLS server using the given certificate/key files (or the certificates
+// already configured in srv.TLSConfig), then serves requests on them.
+//
+// TINYGO: uses software crypto/tls (available on the host/native target); no
+// HTTP/2 negotiation is performed.
+func (srv *Server) ServeTLS(l net.Listener, certFile, keyFile string) error {
+	config := srv.TLSConfig
+	if config == nil {
+		config = &tls.Config{}
+	} else {
+		config = config.Clone()
+	}
+
+	configHasCert := len(config.Certificates) > 0 || config.GetCertificate != nil
+	if !configHasCert || certFile != "" || keyFile != "" {
+		cert, err := tls.LoadX509KeyPair(certFile, keyFile)
+		if err != nil {
+			return err
+		}
+		config.Certificates = []tls.Certificate{cert}
+	}
+
+	tlsListener := tls.NewListener(l, config)
+	return srv.Serve(tlsListener)
+}
+
+// ListenAndServeTLS listens on srv.Addr and serves HTTPS requests, loading the
+// server certificate and key from certFile and keyFile.
+func (srv *Server) ListenAndServeTLS(certFile, keyFile string) error {
+	if srv.shuttingDown() {
+		return ErrServerClosed
+	}
+	addr := srv.Addr
+	if addr == "" {
+		addr = ":https"
+	}
+	ln, err := net.Listen("tcp", addr)
+	if err != nil {
+		return err
+	}
+	defer ln.Close()
+	return srv.ServeTLS(ln, certFile, keyFile)
+}
+
+// ListenAndServeTLS is the HTTPS counterpart of ListenAndServe.
+func ListenAndServeTLS(addr, certFile, keyFile string, handler Handler) error {
+	server := &Server{Addr: addr, Handler: handler}
+	return server.ListenAndServeTLS(certFile, keyFile)
+}
+
 // onceCloseListener wraps a net.Listener, protecting it from
 // multiple Close calls.
 type onceCloseListener struct {


### PR DESCRIPTION
Adds `Server.ServeTLS`, `Server.ListenAndServeTLS` and the package-level `ListenAndServeTLS`, mirroring the standard library (no HTTP/2 negotiation). This also satisfies quic-go/http3's reference to `http.ListenAndServeTLS`.

This pairs with a tinygo-side change that links Go's full software crypto/tls on the host/native target (where the netdev is raw syscalls with no TLS offload, so the hardware-offload crypto/tls wrapper could never work) — PR on the tinygo repo to follow. On netdev targets with TLS offload these methods are additive and unused.

Verified against tinygo dev (0.42.0) with that change: `ServeTLS` on a loopback listener completes a real TLS 1.3 handshake and serves an HTTPS GET to both an in-process `tls.Client` and external `curl -k`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C3X3gvq8ZggMRvzVzWm66i