### PR TITLE
net: implement ListenConfig with explicit option limits

### DIFF
--- a/dial.go
+++ b/dial.go
@@ -222,8 +222,20 @@ type ListenConfig struct {
 //
 // The ctx argument is used while resolving the address on which to listen;
 // it does not affect the returned Listener.
+// TINYGO: netdev.go has no lookup cancellation or socket control hook.
+// Context is checked before and after lookup. Default socket options apply.
 func (lc *ListenConfig) Listen(ctx context.Context, network, address string) (Listener, error) {
-	return nil, errors.New("dial:ListenConfig:Listen not implemented")
+	if err := lc.checkListenConfig(ctx, true); err != nil {
+		return nil, &OpError{Op: "listen", Net: network, Err: err}
+	}
+	laddr, err := ResolveTCPAddr(network, address)
+	if err != nil {
+		return nil, err
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, &OpError{Op: "listen", Net: network, Addr: laddr, Err: err}
+	}
+	return listenTCP(laddr)
 }
 
 // ListenPacket announces on the local network address.
@@ -233,8 +245,35 @@ func (lc *ListenConfig) Listen(ctx context.Context, network, address string) (Li
 //
 // The ctx argument is used while resolving the address on which to listen;
 // it does not affect the returned PacketConn.
+// TINYGO: netdev.go has no lookup cancellation or socket control hook.
+// Context is checked before and after lookup. Default socket options apply.
 func (lc *ListenConfig) ListenPacket(ctx context.Context, network, address string) (PacketConn, error) {
-	return nil, errors.New("dial:ListenConfig:ListenPacket not implemented")
+	if err := lc.checkListenConfig(ctx, false); err != nil {
+		return nil, &OpError{Op: "listen", Net: network, Err: err}
+	}
+	switch network {
+	case "udp", "udp4":
+	default:
+		return nil, fmt.Errorf("Network %s not supported", network)
+	}
+	laddr, err := ResolveUDPAddr(network, address)
+	if err != nil {
+		return nil, err
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, &OpError{Op: "listen", Net: network, Addr: laddr, Err: err}
+	}
+	return ListenUDP(network, laddr)
+}
+
+func (lc *ListenConfig) checkListenConfig(ctx context.Context, stream bool) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if lc.Control != nil || stream && (lc.KeepAlive != 0 || lc.KeepAliveConfig.Enable) {
+		return fmt.Errorf("net: ListenConfig socket options: %w", errors.ErrUnsupported)
+	}
+	return nil
 }
 
 func parseNetwork(ctx context.Context, network string, needsProto bool) (afnet string, proto int, err error) {

--- a/listenconfig_native_test.go
+++ b/listenconfig_native_test.go
@@ -1,0 +1,69 @@
+//go:build linux && !baremetal && !tinygo.wasm
+
+package net
+
+import (
+	"context"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestListenConfigTCPExchange(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	l, err := (&ListenConfig{}).Listen(ctx, "tcp4", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer l.Close()
+	cancel()
+	sa, err := syscall.Getsockname(l.(*listener).fd)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fd, err := syscall.Socket(syscall.AF_INET, syscall.SOCK_STREAM, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer syscall.Close(fd)
+	if err := syscall.Connect(fd, sa); err != nil {
+		t.Fatal(err)
+	}
+	c, err := l.Accept()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.Close()
+	c.SetReadDeadline(time.Now().Add(time.Second))
+	if _, err := syscall.Write(fd, []byte("x")); err != nil {
+		t.Fatal(err)
+	}
+	b := make([]byte, 1)
+	if n, err := c.Read(b); n != 1 || err != nil || b[0] != 'x' {
+		t.Fatalf("read=%d %q error=%v", n, b, err)
+	}
+}
+
+func TestListenConfigUDPReceive(t *testing.T) {
+	c, err := (&ListenConfig{}).ListenPacket(context.Background(), "udp4", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.Close()
+	c.SetReadDeadline(time.Now().Add(time.Second))
+	fd, err := syscall.Socket(syscall.AF_INET, syscall.SOCK_DGRAM, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer syscall.Close(fd)
+	addr := c.LocalAddr().(*UDPAddr)
+	sa := &syscall.SockaddrInet4{Port: addr.Port, Addr: [4]byte{127, 0, 0, 1}}
+	if err := syscall.Sendto(fd, []byte("x"), 0, sa); err != nil {
+		t.Fatal(err)
+	}
+	b := make([]byte, 1)
+	if n, err := c.(*UDPConn).Read(b); n != 1 || err != nil || b[0] != 'x' {
+		t.Fatalf("read=%d %q error=%v", n, b, err)
+	}
+}

--- a/listenconfig_test.go
+++ b/listenconfig_test.go
@@ -1,0 +1,138 @@
+package net
+
+import (
+	"context"
+	"errors"
+	"net/netip"
+	"syscall"
+	"testing"
+	"time"
+)
+
+type listenConfigNetdev struct {
+	nopNetdev
+	lookup  func()
+	sockets int
+	bound   netip.AddrPort
+	listens int
+	closed  int
+}
+
+func (d *listenConfigNetdev) GetHostByName(string) (netip.Addr, error) {
+	if d.lookup != nil {
+		d.lookup()
+	}
+	return netip.MustParseAddr("127.0.0.1"), nil
+}
+func (d *listenConfigNetdev) Socket(int, int, int) (int, error) {
+	d.sockets++
+	return 42, nil
+}
+func (d *listenConfigNetdev) Bind(_ int, addr netip.AddrPort) error {
+	d.bound = addr
+	return nil
+}
+func (d *listenConfigNetdev) Listen(int, int) error {
+	d.listens++
+	return nil
+}
+func (d *listenConfigNetdev) Close(int) error {
+	d.closed++
+	return nil
+}
+
+func testListenConfigCall(lc *ListenConfig, ctx context.Context, network, address string) error {
+	if network == "udp4" {
+		c, err := lc.ListenPacket(ctx, network, address)
+		if err != nil {
+			return err
+		}
+		return c.Close()
+	}
+	l, err := lc.Listen(ctx, network, address)
+	if err != nil {
+		return err
+	}
+	return l.Close()
+}
+
+func TestListenConfigNetdev(t *testing.T) {
+	previous := netdev
+	defer func() { netdev = previous }()
+	for _, network := range []string{"tcp4", "udp4"} {
+		t.Run(network, func(t *testing.T) {
+			d := &listenConfigNetdev{}
+			netdev = d
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			if err := testListenConfigCall(&ListenConfig{}, ctx, network, "test.invalid:12345"); err != nil {
+				t.Fatal(err)
+			}
+			if d.sockets != 1 || d.bound.String() != "127.0.0.1:12345" || d.closed != 1 {
+				t.Fatalf("socket=%d bound=%v close=%d", d.sockets, d.bound, d.closed)
+			}
+			wantListen := 0
+			if network == "tcp4" {
+				wantListen = 1
+			}
+			if d.listens != wantListen {
+				t.Fatalf("listen=%d want %d", d.listens, wantListen)
+			}
+		})
+	}
+}
+
+func TestListenConfigCancellation(t *testing.T) {
+	previous := netdev
+	defer func() { netdev = previous }()
+	for _, network := range []string{"tcp4", "udp4"} {
+		for _, duringLookup := range []bool{false, true} {
+			d := &listenConfigNetdev{}
+			netdev = d
+			ctx, cancel := context.WithCancel(context.Background())
+			if duringLookup {
+				d.lookup = cancel
+			} else {
+				cancel()
+			}
+			err := testListenConfigCall(&ListenConfig{}, ctx, network, "test.invalid:12345")
+			cancel()
+			if !errors.Is(err, context.Canceled) {
+				t.Fatalf("%s duringLookup=%v error=%v", network, duringLookup, err)
+			}
+			if d.sockets != 0 {
+				t.Fatalf("%s opened socket after cancellation", network)
+			}
+		}
+		ctx, cancel := context.WithDeadline(context.Background(), time.Unix(1, 0))
+		err := testListenConfigCall(&ListenConfig{}, ctx, network, "test.invalid:12345")
+		cancel()
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("%s error=%v", network, err)
+		}
+	}
+}
+
+func TestListenConfigUnsupportedOptions(t *testing.T) {
+	previous := netdev
+	defer func() { netdev = previous }()
+	called := false
+	control := func(string, string, syscall.RawConn) error { called = true; return nil }
+	for _, network := range []string{"tcp4", "udp4"} {
+		d := &listenConfigNetdev{}
+		netdev = d
+		err := testListenConfigCall(&ListenConfig{Control: control}, context.Background(), network, "test.invalid:12345")
+		if !errors.Is(err, errors.ErrUnsupported) || called || d.sockets != 0 {
+			t.Fatalf("%s error=%v called=%v sockets=%d", network, err, called, d.sockets)
+		}
+	}
+	for _, lc := range []ListenConfig{{KeepAlive: time.Second}, {KeepAlive: -1}, {KeepAliveConfig: KeepAliveConfig{Enable: true}}} {
+		err := testListenConfigCall(&lc, context.Background(), "tcp4", "test.invalid:12345")
+		if !errors.Is(err, errors.ErrUnsupported) {
+			t.Fatalf("error=%v", err)
+		}
+	}
+	if err := testListenConfigCall(&ListenConfig{KeepAlive: time.Second}, context.Background(), "udp4", "test.invalid:12345"); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/tools/test-listenconfig.sh
+++ b/tools/test-listenconfig.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+set -eu
+
+tinygo_bin=${TINYGO_BIN:-tinygo}
+release_root=$("$tinygo_bin" env TINYGOROOT)
+net_root=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+test_root=$(mktemp -d "${TMPDIR:-/tmp}/net-listenconfig.XXXXXX")
+
+tar -C "$release_root" --exclude='./src/net' -cf - ./src | tar -C "$test_root" -xf -
+mkdir "$test_root/src/net"
+tar -C "$net_root" --exclude='./.git' -cf - . | tar -C "$test_root/src/net" -xf -
+ln -s "$release_root/lib" "$test_root/lib"
+ln -s "$release_root/targets" "$test_root/targets"
+
+TINYGOROOT="$test_root" "$tinygo_bin" test -c -o "$test_root/listenconfig.test" net
+printf 'Test binary: %s\n' "$test_root/listenconfig.test"
+printf 'Run on the target OS with an external timeout and -test.run TestListenConfig\n'


### PR DESCRIPTION
ListenConfig.Listen and ListenPacket currently return a not-implemented error. This stops callers that use a zero ListenConfig even though the netdev can listen.

Use the existing TCP and UDP listen paths. Check context before and after address lookup, before a socket is created. Reject Control and explicit TCP keep-alive settings with an error that wraps errors.ErrUnsupported. UDP ignores TCP keep-alive settings. The netdev has no raw socket control hook. It also has no lookup cancellation hook, so a lookup in progress must return before cancellation is reported. Default socket options and MPTCP fallback stay as provided by the existing netdev.

This replaces the local fork patch 895d524. That patch ignored context and Control. The new tests fail on that patch for both cases.

Validation uses released TinyGo 0.43.0-net.1, Go 1.26.7, and an isolated TINYGOROOT with this net tree. No LLVM build is required. Five tests pass on Linux arm64 and Linux amd64. The amd64 tests ran under emulation on an arm64 host. Tests cover a real TCP exchange, UDP receive, listening after context cancellation following creation, netdev delegation, cancellation before and during lookup, expired context, and rejected options. The native tests use getsockname directly to stay independent of #80. Test processes had an external 20-second timeout. Run tools/test-listenconfig.sh with a released compiler to build the tests in an isolated root.

The [Crier record](https://github.com/yohimik/crier/blob/7edaff9/docs/operations/tinygo.md) describes the original listener failure and a historical Linux arm64 run with 142 passing tests. That run used local listener, shutdown, and cookiejar patches. It predates later Crier changes. It is not validation of this branch or of a new Crier release.

Related work and scope

- #77 owns Linux close cancellation and deadline interruption. This PR does not change socket close or the poller.
- #80 owns the bound TCP port. This PR does not change address reporting.
- #78 owns Dialer.Control API fields and other API additions. ListenConfig is a separate API and this PR does not implement raw socket control.
- #79 owns server TLS methods. #67 owns Client.Timeout and transport selection.
- #72–75 cover client redirects, DNS errors, darwin sockets, and darwin client trust roots.
- tinygo-org/tinygo#5631 is closed in favor of tinygo-org/tinygo#5530 for signal delivery.

This PR is based on net main. It needs no change from those PRs to build or to run these Linux tests.

### Current integration status

Darwin fcntl work is in tinygo-org/tinygo#5612. tinygo-org/tinygo#5632 is closed and remains a history reference only. The integer and pointer tests were offered on #5612. Builder socket and spawn symbols in tinygo-org/tinygo#5636 are an independent prerequisite at 6fded0c9. The direct syscall test needs no net update, so that PR does not wait for this net series. tinygo-org/tinygo#5634 is limited to process support.


### Published fork and downstream evidence

[The net.2 fork release](https://github.com/yohimik/tinygo/releases/tag/v0.43.0-net.2) combines the coordinated changes at `95fba82a`, with net `0f460803`. It differs from accepted candidate `e7d34c8c` only in the version constant. Linux, macOS and Windows branch CI and tag CI passed on their first attempts.

Dispat source `909dc401`, with harness `0990c6db`, passed 796 test events with no failures or skips on each native Darwin ARM64 and Linux ARM64 candidate run. Crier source `7d687fc8` passed raw and stripped E2E on native Linux ARM64 and emulated Linux AMD64, each with 144 top-level tests and 156 passing events, no failures or skips. Both applications use TinyGo-built update fixtures and test trusted TLS, certificate refusal, original backup hashes and byte-identical offline rollback. Their workflows also exercise files, environment variables, concurrency and child processes. Crier includes real FFmpeg and webrender/canvas rendering.

Crier's unchanged 13-image pixel gate passed. It uses an approved two-line explicit-rounding webrender build patch for both compilers. The earlier gradient mismatch was permitted fused arithmetic, not a TinyGo compiler error. Candidate stripped sizes are 13,835,824 versus 30,277,794 Go bytes on ARM64 (54.30% smaller), and 16,446,968 versus 32,518,306 on AMD64 (49.42% smaller).

These are combined-candidate application results, not proof that this PR alone supplies the features. They supersede the earlier Crier comparison. Published-toolchain probes and application acceptance have since completed. The final Crier v1.1.1 release evidence is below. Dispat controls its own publication. WaitDelay, in-flight deadlines and full descriptor lifetime remain open. This enables tested CLI client workflows, not general Go or server compatibility.



### Owner sync, 6 September

The owner of #77 adopted our repeated-Close guard as `9dc11e1`, with tests adapted to its nonblocking sockets. The owner of #80 adopted the Zone correction as `7b7aacb` and removed the test dependency on #82. These are PR branches, not upstream merges.

New #83 restores RoundTripper dispatch. A Git merge check against #72 reports a conflict in `http/client.go`; both behaviors need combined tests before integration. New #84 uses the existing integer-conversion shim in `tlssock.go`. Neither new PR is included in the tested candidate `e7d34c8c`. No duplicate PR is needed.

### Published Crier v1.1.1 evidence

[Crier v1.1.1](https://github.com/yohimik/crier/releases/tag/v1.1.1) is public at source `acac2f0e` and uses published TinyGo `0.43.0-net.2`. Its [final acceptance report](https://github.com/yohimik/crier/releases/download/v1.1.1/crier-v1.1.1-acceptance.md) and [SHA-256 manifest](https://github.com/yohimik/crier/releases/download/v1.1.1/SHA256SUMS) identify the exact release bytes. The public tag, asset sizes and report digest were checked. These final sizes supersede the candidate sizes above.

| Linux target | Standard Go bytes | Stripped TinyGo bytes | Reduction |
| --- | ---: | ---: | ---: |
| ARM64 | 30,277,794 | 13,835,840 | 54.30% |
| AMD64 | 32,518,306 | 16,447,000 | 49.42% |

The report records 144 top-level tests and 156 passing events for each raw and stripped run on native ARM64 and emulated AMD64, with no failures or skips. It covers real CLI files, environment and concurrent work, child processes, TLS, update/rollback fixtures, uploads, real FFmpeg, and webrender/canvas rendering. The unchanged 13-image gate passes on both targets. AMD64 is exact; ARM64 has 12 exact images and four event-card pixels with channel difference 1. Both compilers use the same explicit-rounding webrender build patch. Standard Go tests, 90.6% coverage, lint and docs also pass.

This is combined-fork application evidence, not isolated proof for this PR or general server support. The generic emulated AMD64 `os` closure assertions still fail and also fail with ordinary Go under that emulation; they are not counted as passing. Native AMD64 CI and the final published AMD64 `net` package pass. The report retains other platform and deadline/descriptor limits. Tiny binaries are opt-in; normal install/self-update selects standard Go assets.

### Published Dispat v1.8.1 CLI evidence

[Dispat v1.8.1 CLI](https://github.com/yohimik/dispat/releases/tag/services/dispat/v1.8.1) is public. Its [size and SHA-256 manifest](https://github.com/yohimik/dispat/releases/download/services/dispat/v1.8.1/dispat-binary-sizes.json) records build source `40c58236`, Go 1.26.8 and TinyGo `0.43.0-net.2`. The public asset metadata and manifest digest were checked.

| Linux target | Standard Go bytes | TinyGo bytes | Reduction |
| --- | ---: | ---: | ---: |
| ARM64 | 9,896,098 | 6,299,032 | 36.35% |
| AMD64 | 10,895,522 | 6,697,528 | 38.53% |

These are final published CLI asset sizes, not the earlier candidate measurements. They do not replace the separately identified test evidence or remove known runtime limits. The [full release workflow](https://github.com/yohimik/dispat/actions/runs/34054341541) has now completed successfully at the recorded build source, including its Windows, macOS and Ubuntu checks. This does not change the test and platform limits stated above.


