### PR TITLE
net: use the netItoa shim in tlssock.go

### DIFF
--- a/tlssock.go
+++ b/tlssock.go
@@ -10,7 +10,6 @@ package net
 
 import (
 	"context"
-	"internal/itoa"
 	"io"
 	"net/netip"
 	"strconv"
@@ -29,7 +28,7 @@ func (a *TLSAddr) String() string {
 	if a == nil {
 		return "<nil>"
 	}
-	return JoinHostPort(a.Host, itoa.Itoa(a.Port))
+	return JoinHostPort(a.Host, netItoa(a.Port))
 }
 
 // A TLSConn represents a secured connection.


### PR DESCRIPTION
Fixes #57.

`tlssock.go` still imported `internal/itoa` unconditionally. go1.26 removed that package (its `Itoa` moved to `internal/strconv`), and the repo already carries the version-gated `netItoa` shim (`itoa_go126.go` / `itoa_pre126.go`) for exactly this case — `tlssock.go` was the one remaining direct import, as the issue guessed ("this may just be a silly mistake").

One line changed plus the import removal; `tinygo test net` passes against go1.27 with the dev compiler.
